### PR TITLE
Use protobuf version from compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *_pb2.py
+metricq/_protobuf_version.py
 
 # Created by https://www.gitignore.io/api/c++,cmake,python,virtualenv
 # Edit at https://www.gitignore.io/?templates=c++,cmake,python,virtualenv

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_protoc_version():
 
 def get_protobuf_requirement():
     if _protobuf_version:
-        return _protobuf_version.__protobuf_requirement__
+        return _protobuf_version._protobuf_requirement
 
     return "protobuf=={}".format(get_protoc_version())
 
@@ -104,8 +104,8 @@ def make_proto(command):
         with open(os.path.join(out_dir, "_protobuf_version.py"), "w") as version_file:
             version_file.writelines(
                 [
-                    "__protobuf_version__ = '{}'\n".format(protoc_version),
-                    "__protobuf_requirement__ = 'protobuf=={}'".format(protoc_version),
+                    "_protobuf_version = '{}'\n".format(protoc_version),
+                    "_protobuf_requirement = 'protobuf=={}'".format(protoc_version),
                 ]
             )
 


### PR DESCRIPTION
Fixes #10 

Open tasks:

- [ ] Handle protoc version newer than available protobuf version on PyPI
- [ ] Recompile all proto files if one is missing