### PR TITLE
Issue 27 - Precise and Pretty Timedelta

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.linting.banditEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python.linting.enabled": true,
-    "python.linting.pylintEnabled": false,
-    "python.linting.banditEnabled": true
-}

--- a/metricq/types.py
+++ b/metricq/types.py
@@ -50,7 +50,9 @@ class Timedelta:
         m = re.fullmatch(r"\s*([+-]?\d*[.,]?\d+)\s*([^\d]*)\s*", duration_str)
         if not m:
             raise ValueError(
-                'invalid duration string {}, not of form "number unit"'.format(duration_str)
+                'invalid duration string {}, not of form "number unit"'.format(
+                    duration_str
+                )
             )
         value = float(m.group(1))
         unit = m.group(2)
@@ -144,7 +146,9 @@ class Timedelta:
             return Timedelta(self._value - other._value)
         if isinstance(other, datetime.timedelta):
             return self - Timedelta.from_timedelta(other)
-        raise TypeError("invalid type to subtract from Timedelta: {}".format(type(other)))
+        raise TypeError(
+            "invalid type to subtract from Timedelta: {}".format(type(other))
+        )
 
     def __truediv__(self, factor):
         return Timedelta(self._value // factor)
@@ -247,7 +251,9 @@ class Timestamp:
             return Timestamp(self._value - other.ns)
         if isinstance(other, Timestamp):
             return Timedelta(self._value - other._value)
-        raise TypeError("Invalid type to subtract from Timestamp: {}".format(type(other)))
+        raise TypeError(
+            "Invalid type to subtract from Timestamp: {}".format(type(other))
+        )
 
     def __lt__(self, other: "Timestamp"):
         return self._value < other._value
@@ -304,7 +310,9 @@ class TimeAggregate(NamedTuple):
         )
 
     @staticmethod
-    def from_value_pair(timestamp_before: Timestamp, timestamp: Timestamp, value: float):
+    def from_value_pair(
+        timestamp_before: Timestamp, timestamp: Timestamp, value: float
+    ):
         assert timestamp > timestamp_before
         delta = timestamp - timestamp_before
         return TimeAggregate(

--- a/metricq/types.py
+++ b/metricq/types.py
@@ -50,9 +50,7 @@ class Timedelta:
         m = re.fullmatch(r"\s*([+-]?\d*[.,]?\d+)\s*([^\d]*)\s*", duration_str)
         if not m:
             raise ValueError(
-                'invalid duration string {}, not of form "number unit"'.format(
-                    duration_str
-                )
+                'invalid duration string {}, not of form "number unit"'.format(duration_str)
             )
         value = float(m.group(1))
         unit = m.group(2)
@@ -91,6 +89,28 @@ class Timedelta:
         self._value = value
 
     @property
+    def precise_string(self):
+        if self._value % 1_000 != 0:
+            return f"{self._value}ns"
+
+        elif self._value % 1_000_000 != 0:
+            return f"{self._value // 1_000}μs"
+
+        elif self._value % 1_000_000_000 != 0:
+            return f"{self._value // 1_000_000}ms"
+
+        elif self._value % (1_000_000_000 * 60) != 0:
+            return f"{self._value // 1_000_000_000}s"
+
+        elif self._value % (1_000_000_000 * 3600) != 0:
+            return f"{self._value // 1_000_000_000 * 60}min"
+
+        elif self._value % (1_000_000_000 * 3600 * 24) != 0:
+            return f"{self._value // 1_000_000_000 * 3600}h"
+
+        return f"{self._value // 1_000_000_000 * 3600 * 24}d"
+
+    @property
     def ns(self):
         return self._value
 
@@ -124,9 +144,7 @@ class Timedelta:
             return Timedelta(self._value - other._value)
         if isinstance(other, datetime.timedelta):
             return self - Timedelta.from_timedelta(other)
-        raise TypeError(
-            "invalid type to subtract from Timedelta: {}".format(type(other))
-        )
+        raise TypeError("invalid type to subtract from Timedelta: {}".format(type(other)))
 
     def __truediv__(self, factor):
         return Timedelta(self._value // factor)
@@ -229,9 +247,7 @@ class Timestamp:
             return Timestamp(self._value - other.ns)
         if isinstance(other, Timestamp):
             return Timedelta(self._value - other._value)
-        raise TypeError(
-            "Invalid type to subtract from Timestamp: {}".format(type(other))
-        )
+        raise TypeError("Invalid type to subtract from Timestamp: {}".format(type(other)))
 
     def __lt__(self, other: "Timestamp"):
         return self._value < other._value
@@ -288,9 +304,7 @@ class TimeAggregate(NamedTuple):
         )
 
     @staticmethod
-    def from_value_pair(
-        timestamp_before: Timestamp, timestamp: Timestamp, value: float
-    ):
+    def from_value_pair(timestamp_before: Timestamp, timestamp: Timestamp, value: float):
         assert timestamp > timestamp_before
         delta = timestamp - timestamp_before
         return TimeAggregate(

--- a/metricq/types.py
+++ b/metricq/types.py
@@ -103,12 +103,12 @@ class Timedelta:
             return f"{self._value // 1_000_000_000}s"
 
         elif self._value % (1_000_000_000 * 3600) != 0:
-            return f"{self._value // 1_000_000_000 * 60}min"
+            return f"{self._value // (1_000_000_000 * 60)}min"
 
         elif self._value % (1_000_000_000 * 3600 * 24) != 0:
-            return f"{self._value // 1_000_000_000 * 3600}h"
+            return f"{self._value // (1_000_000_000 * 3600)}h"
 
-        return f"{self._value // 1_000_000_000 * 3600 * 24}d"
+        return f"{self._value // (1_000_000_000 * 3600 * 24)}d"
 
     @property
     def ns(self):

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -1,6 +1,7 @@
 import pytest
+from math import pow
 
-from ..metricq.types import *
+from ..metricq.types import Timedelta
 
 
 @pytest.fixture
@@ -18,22 +19,34 @@ def time_delta_1d():
     return Timedelta(1_000_000_000 * 3600 * 24)
 
 
+@pytest.fixture
+def time_delta_generate_random_list(count=1000):
+    l = []
+
+    v = 8295638928
+    increase = 1243899020259
+    mult = 5
+    mod = 9987868812
+
+    for _ in range(count):
+        l.append(Timedelta(v // 20 * pow(10, v % 20)))
+        v = (v * mult + increase) % mod
+
+    return l
+
+
 def test_timedelta_to_string():
     td1 = time_delta_random()
     td2 = time_delta_1s()
     td3 = time_delta_1d()
 
     assert td1.precise_string == "8295638928ns"
-    assert td1.precise_string == "1s"
-    assert td1.precise_string == "1d"
+    assert td2.precise_string == "1s"
+    assert td3.precise_string == "1d"
 
 
 def test_timedelta_to_string_and_reverse():
-    td1 = time_delta_random()
-    td2 = time_delta_1s()
-    td3 = time_delta_1d()
 
-    assert Timedelta.from_string(td1.precise_string) == td1
-    assert Timedelta.from_string(td2.precise_string) == td2
-    assert Timedelta.from_string(td3.precise_string) == td3
+    for t in time_delta_generate_random_list():
+        assert Timedelta.from_string(t.precise_string) == t
 

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -10,8 +10,33 @@ def time_delta_random():
 
 
 @pytest.fixture
+def time_delta_1us():
+    return Timedelta(1_000)
+
+
+@pytest.fixture
+def time_delta_1ms():
+    return Timedelta(1_000_000)
+
+
+@pytest.fixture
 def time_delta_1s():
     return Timedelta(1_000_000_000)
+
+
+@pytest.fixture
+def time_delta_10s():
+    return Timedelta(10_000_000_000)
+
+
+@pytest.fixture
+def time_delta_1min():
+    return Timedelta(1_000_000_000 * 60)
+
+
+@pytest.fixture
+def time_delta_1h():
+    return Timedelta(1_000_000_000 * 3600)
 
 
 @pytest.fixture
@@ -35,10 +60,24 @@ def time_delta_generate_random_list(count=1000):
     return l
 
 
-def test_timedelta_to_string(time_delta_random, time_delta_1s, time_delta_1d):
+def test_timedelta_to_string(
+    time_delta_random,
+    time_delta_1us,
+    time_delta_1ms,
+    time_delta_1s,
+    time_delta_10s,
+    time_delta_1min,
+    time_delta_1h,
+    time_delta_1d,
+):
 
     assert time_delta_random.precise_string == "8295638928ns"
+    assert time_delta_1us.precise_string == "1μs"
+    assert time_delta_1ms.precise_string == "1ms"
     assert time_delta_1s.precise_string == "1s"
+    assert time_delta_10s.precise_string == "10s"
+    assert time_delta_1min.precise_string == "1min"
+    assert time_delta_1h.precise_string == "1h"
     assert time_delta_1d.precise_string == "1d"
 
 

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -54,7 +54,7 @@ def time_delta_generate_random_list():
 
     yield 0
     for l in range(0, 17, 1):
-        yield pow(10, l)
+        yield Timedelta(pow(10, l))
         for _ in range(c * (l + 1)):
             d = v // 20
             p = v % (l + 1)

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -46,8 +46,8 @@ def time_delta_1d():
 
 @pytest.fixture
 def time_delta_generate_random_list():
-    c = 4
-    v = 20458290249576139
+    count = 4
+    random_number = 20458290249576139
     seed = 72438990202596743
     mult = 7
     mod = 99878688123465600
@@ -55,13 +55,13 @@ def time_delta_generate_random_list():
     yield 0
     for l in range(0, 17, 1):
         yield Timedelta(pow(10, l))
-        for _ in range(c * (l + 1)):
-            d = v // 20
-            p = v % (l + 1)
+        for _ in range(count * (l + 1)):
+            d = random_number // 20
+            p = random_number % (l + 1)
             r = int((d * pow(10, p)) % (pow(10, l + 1)))
             if r != 0:
                 yield Timedelta(r)
-            v = (v * mult + seed) % mod
+            random_number = (random_number * mult + seed) % mod
 
 
 def test_timedelta_to_string(

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -45,19 +45,22 @@ def time_delta_1d():
 
 
 @pytest.fixture
-def time_delta_generate_random_list(count=1000):
-    l = []
-
+def time_delta_generate_random_list():
+    c = 10
     v = 8295638928
-    increase = 1243899020259
+    seed = 1243899020259674347
     mult = 5
-    mod = 9987868812
+    mod = 99878688123465625
 
-    for _ in range(count):
-        l.append(Timedelta(int(v // 20 * pow(10, v % 20))))
-        v = (v * mult + increase) % mod
-
-    return l
+    yield 0
+    for l in range(1, 17, 1):
+        for _ in range(c * l):
+            d = v // 20
+            p = v % l
+            r = (int(d * pow(10, p))) % (pow(10, l - 1))
+            if r != 0:
+                yield Timedelta(r)
+            v = (v * mult + seed) % mod
 
 
 def test_timedelta_to_string(

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -47,10 +47,10 @@ def time_delta_1d():
 @pytest.fixture
 def time_delta_generate_random_list():
     c = 4
-    v = 8295638928
+    v = 20458290249576139
     seed = 72438990202596743
     mult = 7
-    mod = 99878688123465625
+    mod = 99878688123465600
 
     yield 0
     for l in range(0, 17, 1):

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ..metricq.types import *
+
+
+@pytest.fixture
+def time_delta_random():
+    return Timedelta(8295638928)
+
+
+@pytest.fixture
+def time_delta_1s():
+    return Timedelta(1_000_000_000)
+
+
+@pytest.fixture
+def time_delta_1d():
+    return Timedelta(1_000_000_000 * 3600 * 24)
+
+
+def test_timedelta_to_string():
+    td1 = time_delta_random()
+    td2 = time_delta_1s()
+    td3 = time_delta_1d()
+
+    assert td1.precise_string == "8295638928ns"
+    assert td1.precise_string == "1s"
+    assert td1.precise_string == "1d"
+
+
+def test_timedelta_to_string_and_reverse():
+    td1 = time_delta_random()
+    td2 = time_delta_1s()
+    td3 = time_delta_1d()
+
+    assert Timedelta.from_string(td1.precise_string) == td1
+    assert Timedelta.from_string(td2.precise_string) == td2
+    assert Timedelta.from_string(td3.precise_string) == td3
+

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -46,18 +46,19 @@ def time_delta_1d():
 
 @pytest.fixture
 def time_delta_generate_random_list():
-    c = 10
+    c = 4
     v = 8295638928
-    seed = 1243899020259674347
-    mult = 5
+    seed = 72438990202596743
+    mult = 7
     mod = 99878688123465625
 
     yield 0
-    for l in range(1, 17, 1):
-        for _ in range(c * l):
+    for l in range(0, 17, 1):
+        yield pow(10, l)
+        for _ in range(c * (l + 1)):
             d = v // 20
-            p = v % l
-            r = int((d * pow(10, p)) % (pow(10, l - 1)))
+            p = v % (l + 1)
+            r = int((d * pow(10, p)) % (pow(10, l + 1)))
             if r != 0:
                 yield Timedelta(r)
             v = (v * mult + seed) % mod

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -1,7 +1,7 @@
 import pytest
 from math import pow
 
-from ..metricq.types import Timedelta
+from metricq.types import Timedelta
 
 
 @pytest.fixture
@@ -29,24 +29,21 @@ def time_delta_generate_random_list(count=1000):
     mod = 9987868812
 
     for _ in range(count):
-        l.append(Timedelta(v // 20 * pow(10, v % 20)))
+        l.append(Timedelta(int(v // 20 * pow(10, v % 20))))
         v = (v * mult + increase) % mod
 
     return l
 
 
-def test_timedelta_to_string():
-    td1 = time_delta_random()
-    td2 = time_delta_1s()
-    td3 = time_delta_1d()
+def test_timedelta_to_string(time_delta_random, time_delta_1s, time_delta_1d):
 
-    assert td1.precise_string == "8295638928ns"
-    assert td2.precise_string == "1s"
-    assert td3.precise_string == "1d"
+    assert time_delta_random.precise_string == "8295638928ns"
+    assert time_delta_1s.precise_string == "1s"
+    assert time_delta_1d.precise_string == "1d"
 
 
-def test_timedelta_to_string_and_reverse():
+def test_timedelta_to_string_and_reverse(time_delta_generate_random_list):
 
-    for t in time_delta_generate_random_list():
+    for t in time_delta_generate_random_list:
         assert Timedelta.from_string(t.precise_string) == t
 

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -57,7 +57,7 @@ def time_delta_generate_random_list():
         for _ in range(c * l):
             d = v // 20
             p = v % l
-            r = (int(d * pow(10, p))) % (pow(10, l - 1))
+            r = int((d * pow(10, p)) % (pow(10, l - 1)))
             if r != 0:
                 yield Timedelta(r)
             v = (v * mult + seed) % mod


### PR DESCRIPTION
Added `precise_string` function to `Timedelta` for pretty printing of values without loss of precision. -> You can parse it again using `Timedelta.from_string` and you will receive the original `Timedelta`.
Tests included in "tests" folder.
Fixes Issue #27 