### PR TITLE
Improve output of sample tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta'
 [tool.black]
 line-length = 88
 target_version = ['py37']
-include = '\.pyi?$'
+include = '\.py$'
 exclude = '''
 
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ skip_glob = [
     "**/*_pb2.py",
     "**/*_pb2.pyi",
 ]
+skip = [
+    ".tox",
+]
 order_by_type = true
 
 [tool.check-manifest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ tools =
     click
     click_log
     click-completion
+    humanize~=2.5
+    python-dateutil~=2.8
 lint =
     black == 20.8b1
     flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,10 @@ examples =
     click
     click-log
     click-completion
+tools =
+    click
+    click_log
+    click-completion
 lint =
     black == 20.8b1
     flake8

--- a/tools/metricq-discover.py
+++ b/tools/metricq-discover.py
@@ -28,14 +28,23 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import asyncio
+import datetime
 import logging
+import re
+from enum import Enum
+from enum import auto as enum_auto
+from typing import List, Optional, Set
 
 import aio_pika
 import click
 import click_completion
 import click_log
+import humanize
+from dateutil.parser import isoparse as parse_iso_datetime
+from dateutil.tz import tzlocal
 
 import metricq
+from metricq.types import Timedelta
 
 logger = metricq.get_logger()
 logger.setLevel(logging.WARN)
@@ -47,9 +56,119 @@ logger.handlers[0].formatter = logging.Formatter(
 click_completion.init()
 
 
+def camelcase_to_kebabcase(camelcase: str) -> str:
+    # Match empty string preceeding uppercase character, but not at the start
+    # of the word. Replace with '-' and make lowercase to get kebab-case word.
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", camelcase).lower()
+
+
+class IgnoredEvent(Enum):
+    ErrorResponses = enum_auto()
+
+    @classmethod
+    def as_option_names(cls) -> List[str]:
+        return [camelcase_to_kebabcase(name) for name, _ in cls.__members__.items()]
+
+    @classmethod
+    def from_option_name(cls, option: str) -> "IgnoredEvent":
+        member_name = "".join(part.title() for part in option.split("-"))
+        return cls.__members__[member_name]
+
+
+class DiscoverResponse:
+    def __init__(
+        self,
+        alive: bool = True,
+        current_time: Optional[str] = None,
+        starting_time: Optional[str] = None,
+        uptime: Optional[int] = None,
+        metricq_version: Optional[str] = None,
+        hostname: Optional[str] = None,
+    ):
+        self.alive = alive
+        self.metricq_version = metricq_version
+        self.hostname = hostname
+
+        self.current_time = self._parse_datetime(current_time)
+        self.starting_time = self._parse_datetime(starting_time)
+        self.uptime: Optional[datetime.timedelta] = None
+
+        try:
+            if uptime is None:
+                if self.current_time is not None and self.starting_time is not None:
+                    self.uptime = self.current_time - self.starting_time
+            else:
+                self.uptime = (
+                    datetime.timedelta(seconds=uptime)
+                    if uptime < 1e9
+                    else datetime.timedelta(microseconds=int(uptime // 1e3))
+                )
+        except (ValueError, TypeError):
+            pass
+
+    @classmethod
+    def _parse_datetime(cls, iso_string) -> Optional[datetime.datetime]:
+        if iso_string is None:
+            return None
+        else:
+            try:
+                dt = parse_iso_datetime(iso_string)
+                return dt.astimezone(tzlocal()).replace(tzinfo=None)
+            except (AttributeError, ValueError, TypeError, OverflowError) as e:
+                logger.warning("Failed to parse ISO datestring ({}): {}", iso_string, e)
+                return None
+
+    def _fmt_parts(self):
+        unknown_color = "bright_white"
+
+        alive = "alive" if self.alive else click.style("dead", fg="bright_red")
+        yield f"currently {alive},"
+
+        try:
+            yield f"up for {humanize.naturaldelta(self.uptime)}"
+        except Exception:
+            yield click.style("unknown uptime", fg=unknown_color)
+
+        try:
+            yield f"(started {humanize.naturalday(self.starting_time)})"
+        except Exception as e:
+            logger.warning(
+                "Failed to convert {} to naturaltime: {}", self.starting_time, e
+            )
+
+        if self.metricq_version:
+            yield f"running {self.metricq_version}"
+
+        if self.hostname:
+            yield f"on {self.hostname}"
+
+    def __str__(self):
+        return " ".join(self._fmt_parts())
+
+
+class Status(Enum):
+    Ok = enum_auto()
+    Warning = enum_auto()
+    Error = enum_auto()
+
+
+def echo_status(status: Status, token: str, msg: str):
+    style_status = {
+        Status.Ok: {"text": "✔️", "fg": "green"},
+        Status.Warning: {"text": "⚠", "fg": "yellow"},
+        Status.Error: {"text": "❌", "fg": "red"},
+    }
+
+    status_prefix = click.style(**style_status[status])  # type: ignore
+
+    click.echo(f'{status_prefix} {click.style(token, fg="cyan")}: {msg}')
+
+
 class MetricQDiscover(metricq.Agent):
-    def __init__(self, server):
+    def __init__(self, server, timeout: Timedelta, ignore_events: Set[IgnoredEvent]):
         super().__init__("discover", server, add_uuid=True)
+        self.timeout = timeout
+        self.ignore_events: Set[IgnoredEvent] = ignore_events
 
     async def discover(self):
         await self.connect()
@@ -71,65 +190,55 @@ class MetricQDiscover(metricq.Agent):
             cleanup_on_response=False,
         )
 
-        await asyncio.sleep(30)
+        await asyncio.sleep(self.timeout.s)
 
     def on_discover(self, from_token, **kwargs):
-        if "error" in kwargs:
-            logger.warning(
-                "Agent '{}' failed to properly respond to discover: {}",
-                from_token,
-                kwargs["error"],
-            )
-            return
-
-        try:
-            alive = kwargs["alive"]
-        except KeyError:
-            logger.warning(
-                f"Agent '{from_token}' misses 'alive' attribute in discover response"
-            )
-            alive = True
-
-        try:
-            startingTime = kwargs["startingTime"]
-        except KeyError:
-            logger.warning(
-                f"Agent '{from_token}' misses 'startingTime' attribute in discover response"
-            )
-            startingTime = "some time in the past"
-
-        try:
-            if kwargs["uptime"] >= 1e9:
-                uptime = int(kwargs["uptime"] // 1e9)
+        error = kwargs.get("error")
+        if error is not None:
+            if IgnoredEvent.ErrorResponses not in self.ignore_events:
+                echo_status(
+                    Status.Error,
+                    from_token,
+                    f'response indicated an error: {click.style(error, fg="bright_red")}',
+                )
             else:
-                uptime = int(kwargs["uptime"])
-        except KeyError:
-            uptime = "a lot of"
+                logger.debug(f"Ignored error response from {from_token}: {error}")
+        else:
+            self.pretty_print(from_token, response=kwargs)
 
-        try:
-            version = kwargs["version"]
-        except KeyError:
-            version = ""
+    def pretty_print(self, from_token, response: dict):
+        logger.debug("response: {}", response)
 
-        try:
-            metricq_version = "@{}".format(kwargs["metricqVersion"])
-        except KeyError:
-            metricq_version = ""
-
-        click.echo(click.style(from_token, fg="cyan"), nl=False)
-        alive = "✔️" if alive else "❌"
-        click.echo(
-            f": {alive} since {startingTime} (up for {uptime} seconds) {version}",
-            nl=False,
+        alive = bool(response.get("alive"))
+        parsed_response = DiscoverResponse(
+            alive=alive,
+            starting_time=response.get("startingTime"),
+            current_time=response.get("currentTime"),
+            uptime=response.get("uptime"),
+            metricq_version=response.get("metricqVersion"),
+            hostname=response.get("hostname"),
         )
-        click.echo(click.style(metricq_version, fg="red"))
+
+        status = Status.Ok if alive else Status.Warning
+
+        echo_status(status, from_token, str(parsed_response))
 
 
 @click.command()
-@click_log.simple_verbosity_option(logger)
+@click_log.simple_verbosity_option(logger, default="warning")
 @click.option("--server", default="amqp://localhost/")
-def discover_command(server):
-    d = MetricQDiscover(server)
+@click.option("-t", "--timeout", default="30s")
+@click.option(
+    "--ignore",
+    type=click.Choice(IgnoredEvent.as_option_names(), case_sensitive=False),
+    multiple=True,
+)
+def discover_command(server, timeout: str, ignore):
+    d = MetricQDiscover(
+        server,
+        timeout=Timedelta.from_string(timeout),
+        ignore_events=set(IgnoredEvent.from_option_name(event) for event in ignore),
+    )
 
     asyncio.run(d.discover())
 

--- a/tools/metricq-discover.py
+++ b/tools/metricq-discover.py
@@ -83,10 +83,12 @@ class DiscoverResponse:
         starting_time: Optional[str] = None,
         uptime: Optional[int] = None,
         metricq_version: Optional[str] = None,
+        client_version: Optional[str] = None,
         hostname: Optional[str] = None,
     ):
         self.alive = alive
         self.metricq_version = metricq_version
+        self.client_version = client_version
         self.hostname = hostname
 
         self.current_time = self._parse_datetime(current_time)
@@ -135,6 +137,9 @@ class DiscoverResponse:
             logger.warning(
                 "Failed to convert {} to naturaltime: {}", self.starting_time, e
             )
+
+        if self.client_version:
+            yield f"version {self.client_version}"
 
         if self.metricq_version:
             yield f"running {self.metricq_version}"
@@ -216,6 +221,7 @@ class MetricQDiscover(metricq.Agent):
             current_time=response.get("currentTime"),
             uptime=response.get("uptime"),
             metricq_version=response.get("metricqVersion"),
+            client_version=response.get("version"),
             hostname=response.get("hostname"),
         )
 

--- a/tools/metricq-discover.py
+++ b/tools/metricq-discover.py
@@ -67,7 +67,7 @@ class IgnoredEvent(Enum):
 
     @classmethod
     def as_option_names(cls) -> List[str]:
-        return [camelcase_to_kebabcase(name) for name, _ in cls.__members__.items()]
+        return [camelcase_to_kebabcase(name) for name in cls.__members__.keys()]
 
     @classmethod
     def from_option_name(cls, option: str) -> "IgnoredEvent":

--- a/tools/metricq-spy.py
+++ b/tools/metricq-spy.py
@@ -88,11 +88,11 @@ class MetricQSpy(metricq.HistoryClient):
 @click_log.simple_verbosity_option(logger)
 @click.option("--server", default="amqp://localhost/")
 @click.argument("metrics", required=True, nargs=-1)
-def discover_command(server, metrics):
-    d = MetricQSpy(server)
+def spy_command(server, metrics):
+    spy = MetricQSpy(server)
 
-    asyncio.run(d.spy(metrics))
+    asyncio.run(spy.spy(metrics))
 
 
 if __name__ == "__main__":
-    discover_command()
+    spy_command()


### PR DESCRIPTION
This mostly affects `metricq-discover.py`:

* use humanize to print human-readable durations
* print client status first
* add `--timeout` to specify maximum time spent waiting for responses
* add `--ignore` to ignore error responses