### PR TITLE
Split release job

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,8 +3,7 @@ name: Python package
 on: [push]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,8 +34,8 @@ jobs:
       run: |
         isort --diff --check .
 
-  release:
-    needs: [build]
+  build:
+    needs: [test]
     runs-on: ubuntu-latest
 
     steps:
@@ -60,8 +59,8 @@ jobs:
         name: distribution-packages
         path: dist/
      
-  upload:
-    needs: [release]
+  release:
+    needs: [build]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -58,19 +58,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: distribution-packages
-        path: dist/  
-        
-  test-release:
-     needs: [release]
-     runs-on: ubuntu-latest
-     steps:
-     - name: Download distribution artifacts
-       uses: actions/download-artifact@v1
-       with:
-         name: distribution-packages
-         path: dist/
-     - name: Display structure of downloaded files
-       run: ls -R
+        path: dist/
      
   upload:
     needs: [release]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -59,14 +59,36 @@ jobs:
       with:
         name: distribution-packages
         path: dist/  
+        
+  test-release:
+     needs: [release]
+     runs-on: ubuntu-latest
+     steps:
+     - name: Download distribution artifacts
+       uses: actions/download-artifact@v1
+       with:
+         name: distribution-packages
+         path: dist/
+     - name: Display structure of downloaded files
+       run: ls -R
+     
+  upload:
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    
+    steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: distribution-packages
+        path: dist/  
     - name: Publish a Python distribution to PyPI
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
     - name: Reformat version number
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
       id: reformat_release
       uses: frabert/replace-string-action@v1.1
       with:
@@ -74,7 +96,6 @@ jobs:
         string: ${{ github.ref }}
         replace-with: '$1'
     - name: Create Release
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
       id: create_release
       uses: actions/create-release@v1
       env:


### PR DESCRIPTION
Split the release job in a `build` and `upload` (aka `release`) step

Fixes #34

~TODO: rename jobs after #36 is merged~