### PR TITLE
Add history request convenience methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 #
 # See https://pre-commit.com/
 default_language_version:
-  python: python3.8
+  python: python3
 
 repos:
 - repo: https://gitlab.com/pycqa/flake8

--- a/docs/api/history-client.rst
+++ b/docs/api/history-client.rst
@@ -6,6 +6,7 @@ History Client
 .. autoclass:: HistoryClient
     :members:
         connect,
+        get_metrics,
         history_data_request,
         history_last_value,
         history_aggregate,

--- a/docs/api/history-client.rst
+++ b/docs/api/history-client.rst
@@ -21,3 +21,6 @@ History Client
 
 .. autoclass:: HistoryResponse
     :members:
+
+.. autoclass:: InvalidHistoryResponse
+    :show-inheritance:

--- a/docs/api/history-client.rst
+++ b/docs/api/history-client.rst
@@ -10,6 +10,7 @@ History Client
         history_last_value,
         history_aggregate,
         history_aggregate_timeline,
+        history_raw_timeline,
     :member-order: bysource
 
 .. py:currentmodule:: metricq.history_client

--- a/docs/api/history-client.rst
+++ b/docs/api/history-client.rst
@@ -22,6 +22,15 @@ History Client
 
 .. autoclass:: HistoryResponse
     :members:
+        mode,
+        values,
+        aggregates,
+    :member-order: bysource
+
+
+.. autoclass:: HistoryResponseType
+    :members:
+    :member-order: bysource
 
 .. autoclass:: InvalidHistoryResponse
     :show-inheritance:

--- a/docs/api/history-client.rst
+++ b/docs/api/history-client.rst
@@ -8,6 +8,9 @@ History Client
         connect,
         history_data_request,
         history_last_value,
+        history_aggregate,
+        history_aggregate_timeline,
+    :member-order: bysource
 
 .. py:currentmodule:: metricq.history_client
 

--- a/docs/howto/history-client.rst
+++ b/docs/howto/history-client.rst
@@ -1,0 +1,201 @@
+.. _history-client-how-to:
+
+.. highlight:: python
+.. py:currentmodule:: metricq
+
+Fetching historical metric data
+===============================
+
+Databases connected to the MetricQ network provide historical metric data.
+We can use a :class:`HistoryClient` to retrieve this data.
+Compared to :ref:`sink-how-to` and :ref:`source-how-to`,
+we won't need to define our own client, we can use :class:`HistoryClient` directly.
+
+.. note::
+    All code below uses :code:`async/await`, so wrap it accordingly:
+
+    .. code-block::
+
+        import asyncio
+
+        async def run_history_client():
+            // Example code here
+            ...
+
+        asyncio.run_until_complete(run_history_client())
+
+Connecting to the network
+-------------------------
+
+Provide the MetricQ URL to connect to and a :term:`Token` to identify the client:
+
+.. code-block::
+
+    >>> token = "history-example"
+    >>> server = "amqps://user:pass@metricq.example.org/"
+
+Then define the :class:`HistoryClient` and connect it to the network:
+
+.. code-block::
+
+    >>> client = metricq.HistoryClient(token=token, server=server)
+    >>> await client.connect()
+
+If all went well, we are ready to retrieve our data.
+
+Fetching metric metadata
+------------------------
+
+All metrics passing through the MetricQ network have :term:`Metadata` associated with them.
+Using :meth:`~Client.get_metrics`, we can explore for which metrics there is historical data:
+
+.. code-block::
+
+    >>> metric = "elab.ariel.s0.dram.power"
+    >>> await client.get_metrics(metric, historic=True)
+    {
+        'elab.ariel.s0.dram.power': {
+            '_id': 'elab.ariel.s0.dram.power',
+            '_rev': '779-20e76d0b06769485e428d866a40a19e9',
+            'bandwidth': 'cycle',
+            'rate': 20.0,
+            'scope': 'last',
+            'unit': 'W',
+            'source': 'source-elab-lmg670',
+            'date': '2020-10-02T02:00:04.325960+00:00',
+            'historic': True
+        }
+    }
+
+By passing :code:`historic=True`, we limit the results to metrics with historical data only.
+More complicated queries are supported by :meth:`~Client.get_metrics`, see :ref:`metric-lookup` for examples.
+
+Getting the last value of a metric
+----------------------------------
+
+To retrieve only the last value of a metric saved to a database base, use
+
+.. code-block::
+
+    >>> metric = "elab.ariel.s0.dram.power"
+    >>> now = metricq.Timestamp.now()
+    >>> (timestamp, value) = await client.history_last_value(metric)
+    >>> age = now - timestamp
+    >>> print(f"Last entry: {timestamp} ({age} ago) value: {value}")
+    Last entry: [1607604944653649318] 2020-12-10 13:55:44.653649+01:00 (0.624169682s ago) value: 5.2123122215271
+
+
+Aggregates -- summarizing a metric
+----------------------------------
+
+:dfn:`Aggregates` contain information for a metric over a specific span of time,
+for example minimum/maximum/average value, sum, integral, number of data points (*count*) etc.
+Use :meth:`HistoryClient.history_aggregate` to summarize a metric in this way.
+
+In the example below, we retrieve information about the metric :literal:`elab.ariel.s0.dram.power`
+over the last 10 minutes.
+
+.. code-block::
+
+    >>> metric = "elab.ariel.s0.dram.power"
+    >>> now = metricq.Timestamp.now()
+    >>> delta = metricq.Timedelta.from_string("10min")
+    >>> start_time = now - delta
+    >>>
+    >>> aggregate = await client.history_aggregate(
+    >>>     metric, start_time=start_time, end_time=now
+    >>> )
+    >>> print(f"Values in the last {delta.precise_string}: {aggregate}")
+    Values in the last 10min: TimeAggregate(timestamp=Timestamp(1607605522779676000), minimum=4.275346755981445, maximum=11.466414451599121, sum=55397.53575706482, count=11998, integral=2770119258139.6226, active_time=599930363353)
+
+Here, :code:`start_time` and :code:`end_time` delimit the range of values to aggregate.
+Omit either of them or both to aggregate all historical values since/until some point in time.
+
+Multiple aggregates
+-------------------
+
+If you want to retrieve multiple successive aggregates, use :meth:`HistoryClient.history_aggregate_timeline`.
+It returns an iterator of aggregates where each aggregate spans at most a duration of :code:`interval_max`.
+
+This is useful if you want to obtain a rough overview for a metric over a longer period of time.
+In the example below we get an overview of a metric over the last 365 days, with each aggregate covering at most 30 days:
+
+.. code-block::
+
+    >>> metric = "elab.ariel.s0.dram.power"
+    >>> delta = metricq.Timedelta.from_string("356d")
+    >>> interval_max = metricq.Timedelta.from_string("30d")
+    >>> now = metricq.Timestamp.now()
+    >>> start_time = now - delta
+    >>> # Fetch aggregates for values over the past 2 hours, each at most an hour long:
+    >>> aggregates = await client.history_aggregate_timeline(
+    >>>     metric, start_time=start_time, end_time=now, interval_max=interval_max,
+    >>> )
+    >>>
+    >>> print(f"Values for the last {delta.precise_string}")
+    >>> for aggregate in aggregates:
+    >>>     print(aggregate)
+    Values for the last 356d
+    TimeAggregate(timestamp=Timestamp(1576000000000000000), minimum=4.092209875269113, maximum=49.750031412119604, sum=593994374.2714809, count=98658756, integral=5998410892025108.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1577000000000000000), minimum=4.029395457601895, maximum=44.29932484337397, sum=512623432.71681815, count=99704757, integral=5140939976375570.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1578000000000000000), minimum=4.070213303973638, maximum=50.991440138904906, sum=577390774.6533275, count=99734524, integral=5788576471647640.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1579000000000000000), minimum=4.08725953086385, maximum=37.54902472030519, sum=555991185.8951057, count=99468962, integral=5588739148089780.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1580000000000000000), minimum=4.085156064549348, maximum=50.646619296011, sum=522117803.496343, count=88969261, integral=5692853013069647.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1581000000000000000), minimum=4.074948972951139, maximum=37.49095530623182, sum=462386484.7307683, count=93735992, integral=4973650909724805.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1582000000000000000), minimum=4.016890013553053, maximum=31.600963661727302, sum=513875664.22672075, count=99802606, integral=5148844813659733.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1583000000000000000), minimum=4.09505560184217, maximum=32.50840513687335, sum=504241073.58503866, count=99840737, integral=5051357041124994.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1584000000000000000), minimum=3.8778002158455225, maximum=20.456466462178092, sum=566789400.6053987, count=99793322, integral=5680943171485073.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1585000000000000000), minimum=4.055744129198569, maximum=49.848274261152525, sum=577035544.1678637, count=99795005, integral=5781975868653922.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1586000000000000000), minimum=4.090598201216997, maximum=51.71097277085196, sum=428877311.4685728, count=99806981, integral=4297132066602203.5, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1587000000000000000), minimum=3.6805707983731595, maximum=41.30919786870951, sum=477295609.5058164, count=99804732, integral=4783373487851792.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1588000000000000000), minimum=4.052929845492045, maximum=46.47610932352675, sum=430180936.40338314, count=99790197, integral=4310744175027674.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1589000000000000000), minimum=4.045782289231323, maximum=35.317270364484564, sum=428285008.46617925, count=99790000, integral=4291822388062562.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1590000000000000000), minimum=4.037842717663995, maximum=36.109705217910005, sum=577227484.2884533, count=99702528, integral=5792219436779407.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1591000000000000000), minimum=4.109231486484054, maximum=25.28786822296384, sum=1266322950.8599746, count=99759123, integral=1.2692437313689422e+16, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1592000000000000000), minimum=4.012270469843231, maximum=46.371744397447735, sum=855274849.9538565, count=99503304, integral=8586157900774826.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1593000000000000000), minimum=4.018666244768894, maximum=48.16907605898412, sum=489314953.5427221, count=99769118, integral=4905119547247363.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1594000000000000000), minimum=4.021740922113744, maximum=17.19941570890925, sum=422114944.3441083, count=99777911, integral=4230758481433696.5, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1595000000000000000), minimum=3.903405893044394, maximum=17.189800217157934, sum=421671555.77031535, count=99751312, integral=4227204663817987.5, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1596000000000000000), minimum=4.0298144051392155, maximum=17.21305943793546, sum=421677696.36389875, count=99625754, integral=4232455502722522.5, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1597000000000000000), minimum=4.0443300790978025, maximum=42.501395874728, sum=425685373.62433964, count=99692006, integral=4270007113356799.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1598000000000000000), minimum=4.022798681983203, maximum=17.226152306810846, sum=422796585.7939971, count=99797773, integral=4236512307816254.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1599000000000000000), minimum=3.9020380477110543, maximum=37.198339989443255, sum=451322892.4169525, count=99748050, integral=4525474207319798.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1600000000000000000), minimum=4.059901887791767, maximum=50.497292058134455, sum=577018180.6042662, count=99565403, integral=5794758614134834.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1601000000000000000), minimum=-0.42605497043147944, maximum=36.09832763671875, sum=314934986.7391233, count=56394789, integral=5332946931093845.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1602000000000000000), minimum=4.154049873352051, maximum=50.97846984863281, sum=103712609.46623087, count=19998790, integral=5185936811198162.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1603000000000000000), minimum=-0.27197903394699097, maximum=50.9841194152832, sum=140197859.92287374, count=19998832, integral=7010239213612438.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1604000000000000000), minimum=-0.336227685213089, maximum=47.68548583984375, sum=113817063.0869138, count=19998746, integral=5691203189059035.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1605000000000000000), minimum=-0.29484596848487854, maximum=45.82585525512695, sum=183813638.73528534, count=19898286, integral=9249958538284772.0, active_time=1000000000000000)
+    TimeAggregate(timestamp=Timestamp(1606000000000000000), minimum=4.137031078338623, maximum=52.33296203613281, sum=105834719.61448812, count=19998732, integral=5292031471206438.0, active_time=1000000000000000)
+
+Note that some of the :class:`TimeAggregate` instances returned summarize almost 100 million data points (see :code:`count=...`)!
+Still, we get a rough idea of how this metric behaved over the past year without expensive calculations.
+
+Fetching raw values
+-------------------
+
+If you are interested in raw values instead of a aggregates, use :meth:`HistoryClient.history_timeline`:
+
+.. code-block::
+
+    >>> metric = "elab.ariel.s0.dram.power"
+    >>> start_time = metricq.Timestamp.from_iso8601("2020-01-01T00:00:00.0Z")
+    >>> end_time = metricq.Timestamp.from_iso8601("2020-01-01T00:00:00.1Z")
+    >>> values = await client.history_timeline(
+    >>>     metric, start_time=start_time, end_time=end_time
+    >>> )
+    >>> print("Raw values of the first 100ms of 2020:")
+    >>> for raw_tv in  values:
+    >>>     print(raw_tv)
+    Raw values of the first 100ms of 2020:
+    TimeValue(timestamp=Timestamp(1577836799998195277), value=6.260790772048024)
+    TimeValue(timestamp=Timestamp(1577836800008200879), value=4.186786145522286)
+    TimeValue(timestamp=Timestamp(1577836800018206481), value=5.189763454302634)
+    TimeValue(timestamp=Timestamp(1577836800028212083), value=7.070445673918661)
+    TimeValue(timestamp=Timestamp(1577836800038217685), value=4.681345060035232)
+    TimeValue(timestamp=Timestamp(1577836800048223287), value=5.109750890322914)
+    TimeValue(timestamp=Timestamp(1577836800058228890), value=4.449131406548784)
+    TimeValue(timestamp=Timestamp(1577836800068234492), value=4.181990750389552)
+    TimeValue(timestamp=Timestamp(1577836800078240094), value=6.013008404218427)
+    TimeValue(timestamp=Timestamp(1577836800088245696), value=4.734305978764959)
+    TimeValue(timestamp=Timestamp(1577836800098251298), value=5.0495328431393665)

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -6,4 +6,5 @@ How to use this library
 
     sink
     source
+    history-client
     metric-lookup

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -6,3 +6,4 @@ How to use this library
 
     sink
     source
+    metric-lookup

--- a/docs/howto/metric-lookup.rst
+++ b/docs/howto/metric-lookup.rst
@@ -1,0 +1,97 @@
+.. _metric-lookup:
+
+.. py:currentmodule:: metricq
+
+Metric lookup
+=============
+
+The method :meth:`Client.get_metrics` provides an interface for searching metrics available on the network.
+Depending on the arguments passed, a different search strategy is applied.
+If :code:`metadata=True`, the result will be a dictionary mapping matching metrics to their metadata.
+Otherwise a plain list of matching metric names is returned.
+See the API documentation at :meth:`~Client.get_metrics` for more details.
+
+Search by regex
+---------------
+
+If the :code:`selector` is a *PCRE*-style regex, all metrics whose name matches are returned:
+
+.. code-block::
+
+    >>> result = await client.get_metrics(
+    >>>     selector=r"elab\.ariel\..*", metadata=False, historic=True, limit=50
+    >>> )
+
+    >>> for metric in result:
+    >>>     print(metric)
+
+    elab.ariel.board.12V.power
+    elab.ariel.fan.power
+    elab.ariel.power
+    elab.ariel.s0.dram.power
+    elab.ariel.s0.package.power
+    elab.ariel.s0.package.power.chunk_offset
+    elab.ariel.s0.package.power.local_offset
+    elab.ariel.s1.dram.power
+    elab.ariel.s1.package.power
+    elab.ariel.sata.12V.power
+    elab.ariel.sata.5V.power
+    elab.ariel.sum.power
+
+Alternatively, passing a list of metric names to :code:`selector` matches exactly those metrics.
+This is useful if you know want to retrieve metadata for a metric you already know exists.
+
+
+Search by prefix/infix
+----------------------
+
+Call :meth:`~Client.get_metrics` with :code:`prefix=...` to search for metrics whose name starts with the given prefix:
+
+.. code-block::
+
+    >>> result = await client.get_metrics(prefix="ariel", metadata=False, limit=10)
+    >>>
+    >>> for metric in result:
+    >>>     print(metric)
+
+    elab.ariel.board.12V.power
+    elab.ariel.board.12V.power.100Hz
+    elab.ariel.board.12V.power.1Hz
+    elab.ariel.board.5V.power.1Hz
+    elab.ariel.fan.power
+    elab.ariel.fan.power.100Hz
+    elab.ariel.fan.power.1Hz
+    elab.ariel.fan.power.chunk_offset
+    elab.ariel.fan.power.local_offset
+    elab.ariel.fan.voltage
+
+The name of a :term:`Metric` is a string of :literal:`.`-separated *components*.
+Searching for :code:`infix="ariel"` matches all metrics whose name contains the component :code:`ariel`.
+
+.. note::
+    Infix-matches work on components, so :code:`infix="ZZZ"` will *not* match :literal:`abc.dZZZe.fgh`.
+
+.. warning::
+
+    *Infix* lookup is not yet supported for non-historic metrics.
+    You will always need to pass :code:`historic=True`!
+
+.. code-block::
+
+    >>> result = await client.get_metrics(infix="ariel", metadata=False, historic=True, limit=50)
+    >>>
+    >>> for metric in result:
+    >>>     print(metric)
+
+    elab.ariel.board.12V.power
+    elab.ariel.fan.power
+    elab.ariel.power
+    elab.ariel.s0.dram.power
+    elab.ariel.s0.package.power
+    elab.ariel.s0.package.power.chunk_offset
+    elab.ariel.s0.package.power.local_offset
+    elab.ariel.s1.dram.power
+    elab.ariel.s1.package.power
+    elab.ariel.sata.12V.power
+    elab.ariel.sata.5V.power
+    elab.ariel.sum.power

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Welcome to MetricQ's documentation!
 ===================================
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
     :caption: Contents:
 
     howto/index

--- a/metricq/client.py
+++ b/metricq/client.py
@@ -44,6 +44,9 @@ class ManagementRpcPublishError(RpcRequestError):
     pass
 
 
+_GetMetricsResult = Union[Sequence[str], Sequence[dict]]
+
+
 class Client(Agent):
     def __init__(self, *args, client_version: Optional[str] = None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -146,7 +149,7 @@ class Client(Agent):
         prefix: Optional[str] = None,
         infix: Optional[str] = None,
         limit: Optional[int] = None,
-    ) -> Union[Sequence[str], Sequence[dict]]:
+    ) -> _GetMetricsResult:
         """Retrieve information for metrics matching a selector pattern.
 
         Args:

--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -445,8 +445,12 @@ class HistoryClient(Client):
             request_type=HistoryRequestType.LAST_VALUE,
             timeout=timeout,
         )
-        assert len(result) == 1
-        return next(result.values())
+        if len(result) == 1:
+            return next(result.values())
+        else:
+            raise InvalidHistoryResponse(
+                f"Response contains {len(result)} values, expected exactly 1"
+            )
 
     @deprecated(reason="use get_metrics() instead")
     async def history_metric_list(self, selector=None, historic=True, timeout=None):

--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -190,12 +190,12 @@ class HistoryResponse:
                 if :code:`convert=False` and the response does not contain raw values.
         """
         time_ns = 0
-        if self._mode == HistoryResponseType.VALUES:
+        if self._mode is HistoryResponseType.VALUES:
             for time_delta, value in zip(self._proto.time_delta, self._proto.value):
                 time_ns = time_ns + time_delta
                 yield TimeValue(Timestamp(time_ns), value)
             return
-        elif self._mode == HistoryResponseType.EMPTY:
+        elif self._mode is HistoryResponseType.EMPTY:
             return
 
         if not convert:
@@ -205,7 +205,7 @@ class HistoryResponse:
                 )
             )
 
-        if self._mode == HistoryResponseType.AGGREGATES:
+        if self._mode is HistoryResponseType.AGGREGATES:
             for time_delta, proto_aggregate in zip(
                 self._proto.time_delta, self._proto.aggregate
             ):
@@ -215,7 +215,7 @@ class HistoryResponse:
                 yield TimeValue(timestamp, aggregate.mean)
             return
 
-        if self._mode == HistoryResponseType.LEGACY:
+        if self._mode is HistoryResponseType.LEGACY:
             for time_delta, average in zip(
                 self._proto.time_delta, self._proto.value_avg
             ):
@@ -238,7 +238,7 @@ class HistoryResponse:
                 if :code:`convert=False` and the underlying response does not contain aggregates
         """
         time_ns = 0
-        if self._mode == HistoryResponseType.AGGREGATES:
+        if self._mode is HistoryResponseType.AGGREGATES:
             for time_delta, proto_aggregate in zip(
                 self._proto.time_delta, self._proto.aggregate
             ):
@@ -246,7 +246,7 @@ class HistoryResponse:
                 timestamp = Timestamp(time_ns)
                 yield TimeAggregate.from_proto(timestamp, proto_aggregate)
             return
-        elif self._mode == HistoryResponseType.EMPTY:
+        elif self._mode is HistoryResponseType.EMPTY:
             return
 
         if not convert:
@@ -259,7 +259,7 @@ class HistoryResponse:
         if len(self) == 0:
             return
 
-        if self._mode == HistoryResponseType.VALUES:
+        if self._mode is HistoryResponseType.VALUES:
             time_ns = self._proto.time_delta[0]
             previous_timestamp = Timestamp(time_ns)
             # First interval is useless here
@@ -274,7 +274,7 @@ class HistoryResponse:
                 previous_timestamp = timestamp
             return
 
-        if self._mode == HistoryResponseType.LEGACY:
+        if self._mode is HistoryResponseType.LEGACY:
             for time_delta, minimum, maximum, average in zip(
                 self._proto.time_delta,
                 self._proto.value_min,

--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -35,7 +35,7 @@ import aio_pika
 
 from . import history_pb2
 from ._deprecation import deprecated
-from .client import Client
+from .client import Client, _GetMetricsResult
 from .logging import get_logger
 from .rpc import rpc_handler
 from .types import TimeAggregate, Timedelta, Timestamp, TimeValue
@@ -294,6 +294,15 @@ class HistoryClient(Client):
             self.history_connection = None
         self.history_exchange = None
         await super().stop(exception)
+
+    async def get_metrics(self, *args, **kwargs) -> _GetMetricsResult:
+        """Retrieve information for **historic** metrics matching a selector pattern.
+
+        This is like :meth:`Client.get_metrics`, but sets :code:`historic=True` by default.
+        See documentation there for a detailed description of the remaining arguments.
+        """
+        kwargs.setdefault("historic", True)
+        return await super().get_metrics(*args, **kwargs)
 
     async def history_data_request(
         self,

--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -76,6 +76,8 @@ class HistoryResponseType(Enum):
 
 
 class InvalidHistoryResponse(ValueError):
+    """A response to a history request was received, but could not be decoded."""
+
     pass
 
 
@@ -382,6 +384,10 @@ class HistoryClient(Client):
 
         Returns:
             A single aggregate over values of this metric, including minimum/maximum/average/etc. values.
+
+        Raises:
+            InvalidHistoryResponse:
+                if an invalid response was received
         """
         response: HistoryResponse = await self.history_data_request(
             metric=metric,
@@ -430,6 +436,10 @@ class HistoryClient(Client):
 
         Returns:
             An iterator over aggregates for this metric.
+
+        Raises:
+            InvalidHistoryResponse:
+                if an invalid response was received
         """
         response: HistoryResponse = await self.history_data_request(
             metric=metric,
@@ -440,7 +450,10 @@ class HistoryClient(Client):
             timeout=timeout,
         )
 
-        return response.aggregates()
+        try:
+            return response.aggregates()
+        except ValueError:
+            raise InvalidHistoryResponse("Response contained no aggregates")
 
     async def history_last_value(self, metric: str, timeout=60) -> Optional[TimeValue]:
         """Fetch the last value recorded for a metric.
@@ -452,6 +465,10 @@ class HistoryClient(Client):
                 Name of the metric of interest.
             timeout:
                 Operation timeout in seconds.
+
+        Raises:
+            InvalidHistoryResponse:
+                if an invalid response was received
         """
         result = await self.history_data_request(
             metric,
@@ -493,6 +510,10 @@ class HistoryClient(Client):
 
         Returns:
             An iterator over values of this metric.
+
+        Raises:
+            InvalidHistoryResponse:
+                if an invalid response was received
         """
         response: HistoryResponse = await self.history_data_request(
             metric=metric,
@@ -503,7 +524,10 @@ class HistoryClient(Client):
             timeout=timeout,
         )
 
-        return response.values(convert=False)
+        try:
+            return response.values(convert=False)
+        except ValueError:
+            raise InvalidHistoryResponse("Response contained no values")
 
     @deprecated(reason="use get_metrics() instead")
     async def history_metric_list(self, selector=None, historic=True, timeout=None):

--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -466,6 +466,44 @@ class HistoryClient(Client):
                 f"Response contains {len(result)} values, expected exactly 1"
             )
 
+    async def history_raw_timeline(
+        self,
+        metric: str,
+        start_time: Optional[Timestamp] = None,
+        end_time: Optional[Timestamp] = None,
+        timeout=60,
+    ) -> Iterator[TimeValue]:
+        """Retrieve raw values of a metric within the specified span of time.
+
+        Omitting both :literal:`start_time` and :literal:`end_time` yields all values recorded for this metric,
+        omitting either one yields values up to/starting at a point in time.
+
+        Args:
+            metric:
+                Name of the metric.
+            start_time:
+                Only retrieve values from this point in time onward.
+                If omitted, include all values before :literal:`end_time`.
+            end_time:
+                Only aggregate values up to this point in time.
+                If omitted, include all values after :literal:`start_time`.
+            timeout:
+                Operation timeout in seconds.
+
+        Returns:
+            An iterator over values of this metric.
+        """
+        response: HistoryResponse = await self.history_data_request(
+            metric=metric,
+            start_time=start_time,
+            end_time=end_time,
+            interval_max=Timedelta(0),
+            request_type=HistoryRequestType.FLEX_TIMELINE,
+            timeout=timeout,
+        )
+
+        return response.values(convert=False)
+
     @deprecated(reason="use get_metrics() instead")
     async def history_metric_list(self, selector=None, historic=True, timeout=None):
         return await self.get_metrics(

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ lint =
 test =
     pytest
     pytest-asyncio
+    pytest-mock
 typing =
     mypy
     mypy-protobuf

--- a/tests/test_history_client.py
+++ b/tests/test_history_client.py
@@ -99,8 +99,7 @@ async def test_history_no_last_value(
 ):
     patch_history_data_request(mocker, empty_history_response)
 
-    with pytest.raises(InvalidHistoryResponse):
-        await history_client.history_last_value(DEFAULT_METRIC)
+    assert await history_client.history_last_value(DEFAULT_METRIC) is None
 
 
 async def test_timelime_empty(

--- a/tests/test_history_client.py
+++ b/tests/test_history_client.py
@@ -82,5 +82,5 @@ async def test_history_no_last_value(
 ):
     mock_empty_history_response(mocker, DEFAULT_METRIC)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(InvalidHistoryResponse):
         await history_client.history_last_value(DEFAULT_METRIC)

--- a/tests/test_history_client.py
+++ b/tests/test_history_client.py
@@ -101,3 +101,11 @@ async def test_history_no_last_value(
 
     with pytest.raises(InvalidHistoryResponse):
         await history_client.history_last_value(DEFAULT_METRIC)
+
+
+async def test_timelime_empty(
+    history_client: HistoryClient, mocker: MockerFixture, empty_history_response
+):
+    patch_history_data_request(mocker, empty_history_response)
+
+    assert list(await history_client.history_raw_timeline(DEFAULT_METRIC)) == []

--- a/tests/test_history_client.py
+++ b/tests/test_history_client.py
@@ -45,7 +45,7 @@ def patch_history_data_request(
 
 
 def test_iterate_empty_history_response(empty_history_response):
-    assert empty_history_response.mode == HistoryResponseType.EMPTY
+    assert empty_history_response.mode is HistoryResponseType.EMPTY
     assert len(empty_history_response) == 0
     assert len(list(empty_history_response.values())) == 0
     assert len(list(empty_history_response.aggregates())) == 0

--- a/tests/test_history_client.py
+++ b/tests/test_history_client.py
@@ -1,0 +1,86 @@
+from unittest.mock import create_autospec
+
+import pytest
+from pytest_mock import MockerFixture
+
+from metricq import history_pb2
+from metricq.history_client import (
+    HistoryClient,
+    HistoryResponse,
+    InvalidHistoryResponse,
+)
+from metricq.types import TimeAggregate, Timestamp, TimeValue
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def history_client() -> HistoryClient:
+    return HistoryClient(token="history-test", management_url="amqps://invalid./")
+
+
+DEFAULT_METRIC = "test.foo"
+
+
+def mock_history_response(mocker: MockerFixture, **response_fields) -> None:
+    async def mocked(_client, *args, **_kwargs):
+        proto = create_autospec(
+            history_pb2.HistoryResponse, spec_set=True, **response_fields
+        )
+        return HistoryResponse(proto=proto)
+
+    mocker.patch(f"{__name__}.HistoryClient.history_data_request", mocked)
+
+
+def mock_empty_history_response(mocker, metric: str):
+    mock_history_response(mocker, metric=metric, time_delta=[], aggregate=[], value=[])
+
+
+async def test_history_aggregate(history_client: HistoryClient, mocker: MockerFixture):
+    TIME = Timestamp(0)
+    AGGREGATE = create_autospec(history_pb2.HistoryResponse.Aggregate, set_spec=True)
+
+    mock_history_response(
+        mocker,
+        metric=DEFAULT_METRIC,
+        time_delta=[TIME.posix_ns],
+        aggregate=[AGGREGATE],
+    )
+
+    assert await history_client.history_aggregate(
+        DEFAULT_METRIC
+    ) == TimeAggregate.from_proto(timestamp=TIME, proto=AGGREGATE)
+
+
+async def test_history_no_aggregate(
+    history_client: HistoryClient, mocker: MockerFixture
+):
+    mock_empty_history_response(mocker, DEFAULT_METRIC)
+
+    with pytest.raises(InvalidHistoryResponse):
+        await history_client.history_aggregate(DEFAULT_METRIC)
+
+
+async def test_history_last_value(history_client: HistoryClient, mocker: MockerFixture):
+    TIME = Timestamp(0)
+    VALUE = mocker.sentinel.VALUE
+
+    mock_history_response(
+        mocker,
+        metric=DEFAULT_METRIC,
+        time_delta=[TIME.posix_ns],
+        value=[VALUE],
+    )
+
+    assert await history_client.history_last_value(DEFAULT_METRIC) == TimeValue(
+        timestamp=TIME, value=VALUE
+    )
+
+
+async def test_history_no_last_value(
+    history_client: HistoryClient, mocker: MockerFixture
+):
+    mock_empty_history_response(mocker, DEFAULT_METRIC)
+
+    with pytest.raises(AssertionError):
+        await history_client.history_last_value(DEFAULT_METRIC)


### PR DESCRIPTION
Add a few shorthand methods to `HistoryClient` that are easier to work with than `history_data_request()`.
All `HistoryRequestType`s should have a corresponding method, except maybe `FLEX_TIMELINE`. It's returned values are either aggregates or values, so not much is gained by unwrapping the received `HistoryResponse`.

Closes #56.

TODO:

- [x] rename `history_timeline` → `history_raw_timeline`
- [x] default to `historic=True` for `get_metrics`
- [x] split "Aggregate" sections in docs
- [x] add all missing examples
- [x] check that `HistoryResponseType.EMPTY` is not a breaking change