### PR TITLE
Fixes missing non-historic metrics in metricq spy

### DIFF
--- a/tools/metricq-spy.py
+++ b/tools/metricq-spy.py
@@ -55,7 +55,11 @@ class MetricQSpy(metricq.HistoryClient):
         await self.connect()
 
         for pattern in patterns:
-            result = await self.get_metrics(selector=pattern, metadata=True)
+            result = await self.get_metrics(
+                selector=pattern,
+                metadata=True,
+                historic=None,
+            )
 
             for metric, metadata in result.items():
                 click.echo(click.style(metric, fg="cyan"), nl=False)


### PR DESCRIPTION
7998efdf0b0d26e0b0631b9a029f8355d271b0ea changed the default behavior of 
get_metrics