### PR TITLE
Handle error messages in history responses

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include docs/make.bat
 
 include lib/metricq-protobuf/*.proto
 include lib/metricq-protobuf/LICENSE
+include lib/metricq-protobuf/README.md
 include metricq/*_pb2.py
 include metricq/*_pb2.pyi
 include metricq/_protobuf_version.py


### PR DESCRIPTION
We need to propagate error messages from the DBs to the clients. This should do it.

Fixes #62 