### PR TITLE
Augment "chunkSize" to metadata when declaring new metrics

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -66,3 +66,13 @@ Consuming tools might handle and display these fields in a special way.
 :literal:`quantity` (`string`)
     The quantity being measured.
     Ideally this is the same as the last segment of the metric name, e.g. :literal:`"power"` or :literal:`"temperature"`.
+
+:literal:`chunkSize` (`number` or :literal:`null`)
+    The number of data points sent to the network in a single message,
+    see :meth:`Source.chunk_size` and :meth:`Source.send`.
+
+    Setting this to :literal:`null` means that the chunk size is either
+    not known or varies between messages.
+
+    This is useful for monitoring, as :literal:`rate` / :literal:`chunkSize`
+    gives an estimate of the expected message rate for a source.

--- a/metricq/source.py
+++ b/metricq/source.py
@@ -41,7 +41,7 @@ from .exceptions import PublishFailed
 from .logging import get_logger
 from .rpc import rpc_handler
 from .source_metric import SourceMetric
-from .types import Timestamp
+from .types import Metric, Timestamp
 
 logger = get_logger(__name__)
 
@@ -133,7 +133,7 @@ class Source(DataClient):
             You are responsible for handling all relevant exceptions.
         """
 
-    def __getitem__(self, id):
+    def __getitem__(self, id: Metric) -> SourceMetric:
         if id not in self.metrics:
             self.metrics[id] = SourceMetric(id, self, chunk_size=self.chunk_size)
         return self.metrics[id]

--- a/metricq/source.py
+++ b/metricq/source.py
@@ -136,7 +136,10 @@ class Source(DataClient):
     def _augment_metadata(
         self, metrics: Dict[Metric, MetadataDict]
     ) -> Dict[Metric, MetadataDict]:
-        augmented: Dict[Metric, MetadataDict] = dict(**metrics)
+        # Do not modify the user-supplied metadata.  The user expects this to
+        # be a read-only parameter, modifying it without their consent could
+        # lead to surprises.
+        augmented = metrics.copy()
         for metric, metadata in augmented.items():
             # If a SourceMetric has a chunk_size of 0, chunking is disable.
             metadata.setdefault("chunkSize", self[metric].chunk_size)

--- a/metricq/source.py
+++ b/metricq/source.py
@@ -133,6 +133,16 @@ class Source(DataClient):
             self.metrics[id] = SourceMetric(id, self, chunk_size=self.chunk_size)
         return self.metrics[id]
 
+    def _augment_metadata(
+        self, metrics: Dict[Metric, MetadataDict]
+    ) -> Dict[Metric, MetadataDict]:
+        augmented: Dict[Metric, MetadataDict] = dict(**metrics)
+        for metric, metadata in augmented.items():
+            # If a SourceMetric has a chunk_size of 0, chunking is disable.
+            metadata.setdefault("chunkSize", self[metric].chunk_size)
+
+        return augmented
+
     async def declare_metrics(self, metrics: Dict[str, MetadataDict]):
         """Declare a set of :term:`metrics<Metric>` this Source produces values for.
 
@@ -167,6 +177,8 @@ class Source(DataClient):
                             },
                         })
         """
+        metrics = self._augment_metadata(metrics=metrics)
+
         logger.debug("declare_metrics({})", metrics)
         await self.rpc("source.declare_metrics", metrics=metrics)
 

--- a/metricq/source.py
+++ b/metricq/source.py
@@ -93,7 +93,7 @@ class Source(DataClient):
 
     Raises:
         TypeError: if value set is neither :literal:`None` nor an integer
-        ValueError: if value set is not a positive integer
+        ValueError: if value set not a positive, non-zero integer
     """
 
     def __init__(self, *args, **kwargs):

--- a/metricq/source.py
+++ b/metricq/source.py
@@ -81,7 +81,15 @@ class Source(DataClient):
     """
 
     chunk_size: Optional[int] = cast(Optional[int], ChunkSize())
-    """Number of :term:`data points<Data Point>` collected into a chunk before being sent.
+    """Number of :term:`data points<Data Point>` collected *(per metric)* into a chunk before being sent.
+
+    This can be overriden for individual metrics:
+
+        .. code-block:: python
+
+            source = Source(...)
+            source.chunk_size = 10
+            source["example.metric"].chunk_size = 42
 
     Initially, this value is set to :code:`1`, so any data point is sent immediately.
     If set to :code:`None`, automatic chunking is disabled and data points must be sent off to the network manually using :meth:`flush`.

--- a/metricq/source_metric.py
+++ b/metricq/source_metric.py
@@ -29,13 +29,38 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
+from typing import Optional
 
 from .datachunk_pb2 import DataChunk
 from .types import Metric, Timestamp
 
 
+class ChunkSize:
+    def __set_name__(self, owner, name):
+        self._field_name = f"_{name}"
+
+    def __get__(self, instance, cls=None) -> Optional[int]:
+        return getattr(instance, self._field_name)
+
+    def __set__(self, instance, chunk_size: Optional[int]):
+        if chunk_size is not None:
+            if not isinstance(chunk_size, int):
+                raise TypeError("chunk_size must be `None` or a positive integer")
+            if not chunk_size >= 1:
+                raise ValueError(f"chunk_size must be at least 1 ({chunk_size} < 1)")
+
+        setattr(instance, self._field_name, chunk_size)
+
+
 class SourceMetric:
-    def __init__(self, id: Metric, source, chunk_size: int = 1):
+    chunk_size = ChunkSize()
+    """Chunk size of this metric.
+
+    If set to :literal:`None`, chunking is disabled.
+    See :attr:`Source.chunk_size` for more information.
+    """
+
+    def __init__(self, id: Metric, source, chunk_size: Optional[int] = 1):
         self.id = id
         self.source = source
 
@@ -56,7 +81,11 @@ class SourceMetric:
 
     async def send(self, time: Timestamp, value):
         self.append(time, value)
-        if 0 < self.chunk_size <= len(self.chunk.time_delta):
+
+        if self.chunk_size is None:
+            return  # Chunking is disabled
+
+        if self.chunk_size <= len(self.chunk.time_delta):
             await self.flush()
 
     async def error(self, time: Timestamp):

--- a/metricq/source_metric.py
+++ b/metricq/source_metric.py
@@ -31,11 +31,11 @@
 import math
 
 from .datachunk_pb2 import DataChunk
-from .types import Timestamp
+from .types import Metric, Timestamp
 
 
 class SourceMetric:
-    def __init__(self, id, source, chunk_size=1):
+    def __init__(self, id: Metric, source, chunk_size: int = 1):
         self.id = id
         self.source = source
 

--- a/metricq/types.py
+++ b/metricq/types.py
@@ -631,3 +631,8 @@ class TimeAggregate:
     @property
     def mean_sum(self) -> float:
         return self.sum / self.count
+
+
+Metric = str
+"""Type alias for strings that represent metric names
+"""

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,52 @@
+from typing import Type
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+
+from metricq.source import Source
+from metricq.source_metric import SourceMetric
+
+pytestmark = pytest.mark.asyncio
+
+
+class _TestSource(Source):
+    async def task(self):
+        assert False, "This should not be run"
+
+    rpc: AsyncMock
+
+
+@pytest.fixture
+def source():
+
+    with patch("metricq.source.Source.rpc"):
+        source = _TestSource(token="source-test", management_url="amqps://test.invalid")
+        yield source
+
+
+def test_source_metric_chunk_size_invalid(source):
+    with pytest.raises(ValueError):
+        SourceMetric("test.foo", source=source, chunk_size=0)
+
+
+@pytest.mark.parametrize(
+    "chunk_size",
+    [1, 42, None],
+)
+def test_chunk_size_valid(source: _TestSource, chunk_size):
+    source.chunk_size = chunk_size
+    assert source.chunk_size == chunk_size
+
+
+@pytest.mark.parametrize(
+    ("invalid", "exc_type"),
+    [
+        (0, ValueError),
+        (-1, ValueError),
+        (4.2, TypeError),
+        ("2", TypeError),
+    ],
+)
+def test_chunk_size_invalid(source: _TestSource, invalid, exc_type: Type[Exception]):
+    with pytest.raises(exc_type):
+        source.chunk_size = invalid

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,10 +1,8 @@
-from typing import Type
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
 from metricq.source import Source
-from metricq.source_metric import SourceMetric
 
 pytestmark = pytest.mark.asyncio
 
@@ -22,34 +20,6 @@ def source():
     with patch("metricq.source.Source.rpc"):
         source = _TestSource(token="source-test", management_url="amqps://test.invalid")
         yield source
-
-
-def test_source_metric_chunk_size_invalid(source):
-    with pytest.raises(ValueError):
-        SourceMetric("test.foo", source=source, chunk_size=0)
-
-
-@pytest.mark.parametrize(
-    "chunk_size",
-    [1, 42, None],
-)
-def test_chunk_size_valid(source: _TestSource, chunk_size):
-    source.chunk_size = chunk_size
-    assert source.chunk_size == chunk_size
-
-
-@pytest.mark.parametrize(
-    ("invalid", "exc_type"),
-    [
-        (0, ValueError),
-        (-1, ValueError),
-        (4.2, TypeError),
-        ("2", TypeError),
-    ],
-)
-def test_chunk_size_invalid(source: _TestSource, invalid, exc_type: Type[Exception]):
-    with pytest.raises(exc_type):
-        source.chunk_size = invalid
 
 
 def assert_declare_metrics(source: _TestSource, metrics):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -50,3 +50,47 @@ def test_chunk_size_valid(source: _TestSource, chunk_size):
 def test_chunk_size_invalid(source: _TestSource, invalid, exc_type: Type[Exception]):
     with pytest.raises(exc_type):
         source.chunk_size = invalid
+
+
+def assert_declare_metrics(source: _TestSource, metrics):
+    assert source.rpc.call_args_list == [
+        call("source.declare_metrics", metrics=metrics)
+    ]
+
+
+async def test_source_declare_metrics_augment_chunk_size(source: _TestSource):
+    """Assert that chunkSize is added to metadata when declaring metrics"""
+    source.chunk_size = 42
+    await source.declare_metrics({"test.foo": {}})
+
+    assert_declare_metrics(source, metrics={"test.foo": {"chunkSize": 42}})
+
+
+async def test_source_declare_metrics_augment_chunk_size_override(source: _TestSource):
+    """Assert that chunkSize in metadata can be overridden per-metric"""
+
+    source["test.chunk-size.override"].chunk_size = 1337
+    source["test.chunk-size.disabled"].chunk_size = None
+
+    await source.declare_metrics(
+        {
+            # Use default chunk size (Source.chunk_size)
+            "test.chunk-size.default": {},
+            # Override with value set on SourceMetric
+            "test.chunk-size.override": {},
+            # Override with an explicitly provided metadata key
+            "test.chunk-size.override-explicit": {"chunkSize": 99},
+            # A SourceMetric with chunking disabled (chunk_size=0) sets chunkSize=None
+            "test.chunk-size.disabled": {},
+        }
+    )
+
+    assert_declare_metrics(
+        source,
+        metrics={
+            "test.chunk-size.default": {"chunkSize": source.chunk_size},
+            "test.chunk-size.override": {"chunkSize": 1337},
+            "test.chunk-size.override-explicit": {"chunkSize": 99},
+            "test.chunk-size.disabled": {"chunkSize": None},
+        },
+    )

--- a/tests/test_source_metric.py
+++ b/tests/test_source_metric.py
@@ -1,0 +1,144 @@
+from math import isnan
+from typing import Generator, Tuple, Type
+from unittest.mock import AsyncMock, create_autospec
+
+import pytest
+
+from metricq.datachunk_pb2 import DataChunk
+from metricq.source import Source
+from metricq.source_metric import ChunkSize, SourceMetric
+from metricq.types import Timedelta, Timestamp
+
+pytestmark = pytest.mark.asyncio
+
+
+_Metric = Generator[Tuple[Timestamp, float], None, None]
+
+
+@pytest.fixture(scope="module")
+def metric() -> _Metric:
+    def _metric():
+        timestamp = Timestamp(0)
+        delta = Timedelta.from_s(1)
+        value = 0.0
+
+        while True:
+            yield (timestamp, value)
+            timestamp += delta
+            value += 1.0
+
+    return _metric()
+
+
+class _Chunked:
+    chunk_size = ChunkSize()
+
+
+@pytest.fixture
+def chunked() -> _Chunked:
+    return _Chunked()
+
+
+@pytest.mark.parametrize(
+    "chunk_size",
+    [1, 42, None],
+)
+def test_chunk_size_valid(chunk_size, chunked):
+    chunked.chunk_size = chunk_size
+    assert chunked.chunk_size == chunk_size
+
+
+@pytest.mark.parametrize(
+    ("invalid", "exc_type"),
+    [
+        (0, ValueError),
+        (-1, ValueError),
+        (4.2, TypeError),
+        ("2", TypeError),
+    ],
+)
+def test_chunk_size_invalid(chunked: _Chunked, invalid, exc_type: Type[Exception]):
+    with pytest.raises(exc_type):
+        chunked.chunk_size = invalid
+
+
+@pytest.fixture
+def source():
+    source = create_autospec(Source, spec_set=True)
+    return source
+
+
+@pytest.fixture
+def source_metric(source):
+    return SourceMetric(id="test.metric", source=source)
+
+
+def test_source_metric_chunk_size_invalid(source):
+    with pytest.raises(ValueError):
+        SourceMetric("test.foo", source=source, chunk_size=0)
+
+
+def test_source_metric_empty_after_init(source):
+    source_metric = SourceMetric(id="test.metric", source=source)
+
+    assert source_metric.empty
+
+
+async def test_source_metric_default_send_immediately(
+    source_metric: SourceMetric, metric: _Metric
+):
+    await source_metric.send(*next(metric))
+
+    source_metric.source._send.assert_called_once()
+
+
+async def test_source_metric_no_send_if_empty(source_metric: SourceMetric):
+    assert source_metric.empty
+
+    await source_metric.flush()
+
+    assert not source_metric.source._send.called
+
+
+async def test_source_metric_send_chunked(source_metric: SourceMetric, metric: _Metric):
+    source_metric.chunk_size = 2
+
+    await source_metric.send(*next(metric))
+    assert not source_metric.source._send.called
+
+    await source_metric.send(*next(metric))
+    assert source_metric.source._send.called
+    assert source_metric.empty
+
+    await source_metric.send(*next(metric))
+    assert len(source_metric.source._send.mock_calls) == 1
+
+
+async def test_source_send_no_chunking(source_metric: SourceMetric, metric: _Metric):
+    source_metric.chunk_size = None
+
+    for _ in range(50):
+        await source_metric.send(*next(metric))
+
+    assert not source_metric.source._send.called
+
+    chunk = source_metric.chunk
+    assert len(chunk.time_delta) == 50
+    assert len(chunk.value) == 50
+
+    await source_metric.flush()
+
+    assert source_metric.empty
+    source_metric.source._send.assert_called_once_with(source_metric.id, chunk)
+
+
+async def test_source_send_error_value_is_none(source_metric: SourceMetric):
+    async def send(metric, chunk: DataChunk):
+        assert len(chunk.value) == 1 and isnan(chunk.value[0])
+
+    # Replace the send call by a mock and inspect it there.  We cannot inspect
+    # the chunk from mock_calls after the call to error since the chunk will
+    # have been reset already, so it would always be empty.
+    source_metric.source.attach_mock(AsyncMock(side_effect=send), "_send")
+
+    await source_metric.error(Timestamp(0))


### PR DESCRIPTION
This fixes #65 by adding "chunkSize" to the metadata of each metric before sending the `source.declare_metrics` RPC.

Technically, this introduces a **breaking change** (so I marked it as 2.0.0):

* 4dc2190: `chunk_size` is validated before assignment, that may raise an exception. Assigning `0` instead of `None` is now an error, where before it was silently converted

Some minor issues that I originally found here moved to #74.