### PR TITLE
Require python 3.8 for ssl fixes

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages =
     metricq_proto
 package_dir =
     metricq_proto = lib/metricq-protobuf
-python_requires = >=3.7
+python_requires = >=3.8
 
 # For runtime dependencies (install_requires), see setup.py.
 # We need to dynamically determine a protobuf version, so we


### PR DESCRIPTION
SSL is sometimes broken in python 3.7 preventing clients from stopping. So we require python 3.8