### PR TITLE
Fix TimeAggregate member types

### DIFF
--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -299,7 +299,7 @@ class HistoryResponse:
                     maximum=maximum,
                     sum=average,
                     count=1,
-                    integral=0,
+                    integral_ns=0,
                     active_time=Timedelta(0),
                 )
             return

--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -300,7 +300,7 @@ class HistoryResponse:
                     sum=average,
                     count=1,
                     integral=0,
-                    active_time=0,
+                    active_time=Timedelta(0),
                 )
             return
 

--- a/metricq/types.py
+++ b/metricq/types.py
@@ -33,7 +33,7 @@ import re
 from dataclasses import dataclass
 from functools import total_ordering
 from numbers import Real
-from typing import Union
+from typing import Union, overload
 
 from . import history_pb2
 from .exceptions import NonMonotonicTimestamps
@@ -247,6 +247,18 @@ class Timedelta:
         microseconds = self._value // 1000
         return datetime.timedelta(microseconds=microseconds)
 
+    @overload
+    def __add__(self, other: "Timedelta") -> "Timedelta":
+        ...
+
+    @overload
+    def __add__(self, other: "Timestamp") -> "Timestamp":
+        ...
+
+    @overload
+    def __add__(self, other: datetime.timedelta) -> "Timedelta":
+        ...
+
     def __add__(self, other: Union["Timedelta", "Timestamp", datetime.timedelta]):
         if isinstance(other, Timedelta):
             return Timedelta(self._value + other._value)
@@ -254,6 +266,18 @@ class Timedelta:
             return self + Timedelta.from_timedelta(other)
         # Fallback to Timestamp.__add__
         return other + self
+
+    @overload
+    def __sub__(self, other: "Timedelta") -> "Timedelta":
+        ...
+
+    @overload
+    def __sub__(self, other: "Timestamp") -> "Timestamp":
+        ...
+
+    @overload
+    def __sub__(self, other: datetime.timedelta) -> "Timedelta":
+        ...
 
     def __sub__(self, other: Union["Timedelta", "Timestamp", datetime.timedelta]):
         if isinstance(other, Timedelta):
@@ -264,10 +288,10 @@ class Timedelta:
             "invalid type to subtract from Timedelta: {}".format(type(other))
         )
 
-    def __truediv__(self, factor):
+    def __truediv__(self, factor) -> "Timedelta":
         return Timedelta(self._value // factor)
 
-    def __mul__(self, factor):
+    def __mul__(self, factor) -> "Timedelta":
         return Timedelta(self._value * factor)
 
     def __str__(self):
@@ -439,6 +463,14 @@ class Timestamp:
             :class:`Timestamp`
         """
         return Timestamp(self._value + delta.ns)
+
+    @overload
+    def __sub__(self, other: "Timedelta") -> "Timestamp":
+        ...
+
+    @overload
+    def __sub__(self, other: "Timestamp") -> "Timedelta":
+        ...
 
     def __sub__(self, other: Union["Timedelta", "Timestamp"]):
         if isinstance(other, Timedelta):

--- a/metricq/types.py
+++ b/metricq/types.py
@@ -576,9 +576,8 @@ class TimeAggregate:
     # TODO maybe convert to 1s based integral (rather than 1ns)
     integral: float
     """integral of all values over the whole period"""
-    # TODO maybe convert to Timedelta
-    active_time: int
-    """time spanned by this aggregate in nanoseconds"""
+    active_time: Timedelta
+    """time spanned by this aggregate"""
 
     @staticmethod
     def from_proto(timestamp: Timestamp, proto: history_pb2.HistoryResponse.Aggregate):
@@ -589,7 +588,7 @@ class TimeAggregate:
             sum=proto.sum,
             count=proto.count,
             integral=proto.integral,
-            active_time=proto.active_time,
+            active_time=Timedelta(proto.active_time),
         )
 
     @staticmethod
@@ -601,7 +600,7 @@ class TimeAggregate:
             sum=value,
             count=1,
             integral=0,
-            active_time=0,
+            active_time=Timedelta(0),
         )
 
     @staticmethod
@@ -629,19 +628,19 @@ class TimeAggregate:
             sum=value,
             count=1,
             integral=delta.ns * value,
-            active_time=delta.ns,
+            active_time=delta,
         )
 
     @property
     def mean(self) -> float:
-        if self.active_time > 0:
+        if self.active_time.ns > 0:
             return self.mean_integral
         else:
             return self.mean_sum
 
     @property
     def mean_integral(self) -> float:
-        return self.integral / self.active_time
+        return self.integral / self.active_time.ns
 
     @property
     def mean_sum(self) -> float:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -155,7 +155,7 @@ def test_timeaggregate_from_value(timestamp):
     assert agg.minimum == VALUE
     assert agg.maximum == VALUE
     assert agg.sum == VALUE
-    assert agg.integral == 0
+    assert agg.integral_ns == 0
 
     assert isclose(agg.mean, VALUE)
     assert isclose(agg.mean_sum, VALUE)
@@ -179,7 +179,7 @@ def test_timeaggregate_from_value_pair(timestamp: Timestamp, time_delta_10s: Tim
     assert agg.minimum == VALUE
     assert agg.maximum == VALUE
     assert agg.sum == VALUE
-    assert agg.integral == time_delta_10s.ns * VALUE
+    assert agg.integral_ns == time_delta_10s.ns * VALUE
 
     assert isclose(agg.mean, VALUE)
     assert isclose(agg.mean_integral, VALUE)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from math import isclose, pow
+from math import isclose
 from random import Random
 
 import pytest
@@ -112,7 +112,7 @@ def timedelta_random_list():
 
 def powers_of_ten():
     for i in range(17):
-        yield Timedelta(pow(10, i))
+        yield Timedelta(10 ** i)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,12 +1,18 @@
 from logging import getLogger
-from math import pow
+from math import isclose, pow
 from random import Random
 
 import pytest
 
-from metricq.types import Timedelta
+from metricq.exceptions import NonMonotonicTimestamps
+from metricq.types import TimeAggregate, Timedelta, Timestamp
 
 logger = getLogger(__name__)
+
+
+@pytest.fixture
+def timestamp():
+    return Timestamp.from_iso8601("2021-03-03T18:00:0.0Z")
 
 
 @pytest.fixture
@@ -136,3 +142,56 @@ def test_timedelta_precise_string_roundtrip(values):
 )
 def test_timedelta_from_string(input, expected_ns):
     assert Timedelta.from_string(input) == Timedelta(expected_ns)
+
+
+def test_timeaggregate_from_value(timestamp):
+    VALUE = 42.0
+    agg = TimeAggregate.from_value(timestamp=timestamp, value=VALUE)
+
+    assert agg.timestamp == timestamp
+    assert agg.active_time == Timedelta(0)
+    assert agg.count == 1
+
+    assert agg.minimum == VALUE
+    assert agg.maximum == VALUE
+    assert agg.sum == VALUE
+    assert agg.integral == 0
+
+    assert isclose(agg.mean, VALUE)
+    assert isclose(agg.mean_sum, VALUE)
+
+    with pytest.raises(ZeroDivisionError):
+        agg.mean_integral
+
+
+def test_timeaggregate_from_value_pair(timestamp: Timestamp, time_delta_10s: Timedelta):
+    VALUE = 42.0
+    later = timestamp + time_delta_10s
+
+    agg = TimeAggregate.from_value_pair(
+        timestamp_before=timestamp, timestamp=later, value=VALUE
+    )
+
+    assert agg.timestamp == timestamp
+    assert agg.active_time == time_delta_10s
+    assert agg.count == 1
+
+    assert agg.minimum == VALUE
+    assert agg.maximum == VALUE
+    assert agg.sum == VALUE
+    assert agg.integral == time_delta_10s.ns * VALUE
+
+    assert isclose(agg.mean, VALUE)
+    assert isclose(agg.mean_integral, VALUE)
+    assert isclose(agg.mean_sum, VALUE)
+
+
+def test_timeaggregate_from_value_pair_non_monotonic(
+    timestamp: Timestamp, time_delta_10s: Timedelta
+):
+    later = timestamp + time_delta_10s
+
+    with pytest.raises(NonMonotonicTimestamps):
+        TimeAggregate.from_value_pair(
+            timestamp_before=later, timestamp=timestamp, value=42.0
+        )


### PR DESCRIPTION
This implements/resolves #76.

Todo:

* [x] Make `TimeAggregate.active_time` a `Timedelta`
* [x] Figure out what to do with `TimeAggregate.integral`:
    - deprecate `integral`, document accordingly
    - add `integral_s`/`integral_ns`
    - document all new properties