### PR TITLE
Make `IntervalSource.period` a `Timedelta`

### DIFF
--- a/metricq/interval_source.py
+++ b/metricq/interval_source.py
@@ -84,17 +84,20 @@ class IntervalSource(Source):
         self._interval_task_stop_future = None
 
     @property
-    def period(self) -> Optional[float]:
-        """Time interval (in seconds) at which :meth:`update` is called.
+    def period(self) -> Optional[Timedelta]:
+        """Time interval at which :meth:`update` is called.
 
         You can set this value at any time and it will be picked up before the next time :meth:`update` is run.
+
+        .. versionchanged:: 2.0.0
+            Return period as :class:`Timedelta` instead of a number of seconds.
         """
         if self._period is None:
             return None
-        return self._period.s
+        return self._period
 
     @period.setter
-    def period(self, duration: Union[float, Timedelta]):  # type: ignore
+    def period(self, duration: Union[float, Timedelta]):  # type: ignore # see comment in __init__()
         if isinstance(duration, Timedelta):
             self._period = duration
         else:

--- a/tests/test_interval_source.py
+++ b/tests/test_interval_source.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from metricq.interval_source import IntervalSource
+from metricq.types import Timedelta
+
+pytestmark = pytest.mark.asyncio
+
+
+class _TestIntervalSource(IntervalSource):
+    async def update(self):
+        assert False, "This should not be run"
+
+    rpc: AsyncMock
+
+
+@pytest.fixture
+def interval_source():
+
+    with patch("metricq.interval_source.IntervalSource.rpc"):
+        source = _TestIntervalSource(
+            token="source-interval-test", management_url="amqps://test.invalid"
+        )
+        yield source
+
+
+@pytest.mark.parametrize(
+    ("period", "normalized"),
+    [
+        (Timedelta(1337), Timedelta(1337)),
+        (4, Timedelta.from_s(4)),
+    ],
+)
+def test_period_setter_normalizing(
+    interval_source: _TestIntervalSource, period, normalized
+):
+    """Internally, the interval source period is normalized to a Timedelta"""
+    assert interval_source.period is None
+
+    interval_source.period = period
+    assert interval_source.period == normalized
+
+
+def test_period_no_reset(interval_source: _TestIntervalSource):
+    """Currently, the interval source period cannot be reset to None"""
+
+    with pytest.raises(TypeError):
+        # type checking warns you that this is not supported
+        interval_source.period = None  # type: ignore


### PR DESCRIPTION
This fixes #81.

Currently based on #82, needs to be rebased once that is merged.