### PR TITLE
Properly parse ISO 8601 date strings to Timestamp

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,10 @@ extensions = [
     "scanpydoc.definition_list_typed_field",
 ]
 
-intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
+}
 
 # See https://icb-scanpydoc.readthedocs-hosted.com/en/latest/scanpydoc.elegant_typehints.html
 # why this is necessary.

--- a/setup.py
+++ b/setup.py
@@ -236,6 +236,7 @@ setup(
     install_requires=[
         "aio-pika~=6.7, >=6.7.1",
         get_protobuf_requirement(),
+        "python-dateutil ~= 2.8, >=2.8.1",
         "yarl",
         "setuptools",
     ],

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -13,7 +13,7 @@ logger = getLogger(__name__)
 
 @pytest.fixture
 def timestamp():
-    return Timestamp.from_iso8601("2021-03-03T18:00:0.0Z")
+    return Timestamp.from_iso8601("2021-03-03T18:00:00Z")
 
 
 @pytest.fixture
@@ -247,3 +247,20 @@ def test_timeaggregate_from_value_pair_non_monotonic(
         TimeAggregate.from_value_pair(
             timestamp_before=later, timestamp=timestamp, value=42.0
         )
+
+
+@pytest.mark.parametrize(
+    ("date_string", "expected"),
+    [
+        # Sanity check
+        ("1970-01-01T00:00:00Z", Timestamp(0)),
+        # Parser supports sub-second digits
+        ("1970-01-01T00:00:00.0Z", Timestamp(0)),
+        # Parser drops sub-microsecond digits
+        ("1970-01-01T00:00:00.000001337Z", Timestamp(1000)),
+        # Timezones other that UTC are supported
+        ("1970-01-01T00:00:00-01:00", Timestamp(Timedelta.from_string("1h").ns)),
+    ],
+)
+def test_timestamp_from_iso8601(date_string: str, expected: Timestamp):
+    assert Timestamp.from_iso8601(date_string) == expected


### PR DESCRIPTION
This implements #7, option 2.