### PR TITLE
IntervalSource: Raise descriptive error on period reset

### DIFF
--- a/metricq/interval_source.py
+++ b/metricq/interval_source.py
@@ -89,6 +89,9 @@ class IntervalSource(Source):
 
         You can set this value at any time and it will be picked up before the next time :meth:`update` is run.
 
+        Note:
+            Currently, the interval source period cannot be reset to :code:`None`.
+
         .. versionchanged:: 2.0.0
             Return period as :class:`Timedelta` instead of a number of seconds.
         """
@@ -100,6 +103,9 @@ class IntervalSource(Source):
     def period(self, duration: Union[float, Timedelta]):  # type: ignore # see comment in __init__()
         if isinstance(duration, Timedelta):
             self._period = duration
+        elif duration is None:
+            # Raise a descriptive exception if someone tries to reset the period.
+            raise TypeError("Cannot reset period to None once set")
         else:
             self._period = Timedelta.from_s(duration)
 

--- a/tests/test_interval_source.py
+++ b/tests/test_interval_source.py
@@ -45,6 +45,6 @@ def test_period_setter_normalizing(
 def test_period_no_reset(interval_source: _TestIntervalSource):
     """Currently, the interval source period cannot be reset to None"""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Cannot reset period"):
         # type checking warns you that this is not supported
         interval_source.period = None  # type: ignore


### PR DESCRIPTION
Resetting `IntervalSource.period` is not yet supported.