### PR TITLE
feat: add required py.typed file to support typing when used as library

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ include lib/metricq-protobuf/README.md
 include metricq/*_pb2.py
 include metricq/*_pb2.pyi
 include metricq/_protobuf_version.py
+include metricq/py.typed
 
 include pyproject.toml
 include *.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ package_dir =
     metricq_proto = lib/metricq-protobuf
 python_requires = >=3.8
 
+[options.package_data]
+metricq = py.typed
+
 # For runtime dependencies (install_requires), see setup.py.
 # We need to dynamically determine a protobuf version, so we
 # cannot put these dependencies here.

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,11 @@ test =
     pytest-asyncio
     pytest-mock
 typing =
-    mypy>=0.810
+    mypy>=0.900
     mypy-protobuf
+    types-setuptools
+    types-protobuf
+    types-python-dateutil
 docs =
     sphinx ~= 3.0
     sphinx_rtd_theme ~= 0.4.3


### PR DESCRIPTION
Requires ~current mypy master~ mypy v0.900 for `@total_ordering` to work

Maybe we should check typing in our other python projects, if everything works as expected