### PR TITLE
feat: add a connection name for better identification in the management UI

### DIFF
--- a/metricq/data_client.py
+++ b/metricq/data_client.py
@@ -80,7 +80,10 @@ class DataClient(Client):
                 URL(dataServerAddress).with_password("***"),
             )
             self.data_server_address = dataServerAddress
-            self.data_connection = await self.make_connection(self.data_server_address)
+            self.data_connection = await self.make_connection(
+                self.data_server_address,
+                connection_name="data connection {}".format(self.token),
+            )
 
             self.data_connection.add_close_callback(self._on_data_connection_close)
             self.data_connection.add_reconnect_callback(

--- a/metricq/history_client.py
+++ b/metricq/history_client.py
@@ -331,7 +331,10 @@ class HistoryClient(Client):
         logger.debug("register response: {}", response)
 
         self.data_server_address = self.derive_address(response["dataServerAddress"])
-        self.history_connection = await self.make_connection(self.data_server_address)
+        self.history_connection = await self.make_connection(
+            self.data_server_address,
+            connection_name="history connection {}".format(self.token),
+        )
         self.history_channel = await self.history_connection.channel()
         self.history_exchange = await self.history_channel.declare_exchange(
             name=response["historyExchange"], passive=True

--- a/setup.py
+++ b/setup.py
@@ -234,6 +234,8 @@ class ProtoDevelop(develop):
 # For all other setuptools options, see setup.cfg
 setup(
     install_requires=[
+        # TODO remove outer client_properties in metricq.agent.Agent.make_connection with aiormq >= 5.1.1, which might
+        #  be available with the next aio-pika release
         "aio-pika~=6.7, >=6.7.1",
         get_protobuf_requirement(),
         "python-dateutil ~= 2.8, >=2.8.1",


### PR DESCRIPTION
The connection name has the form "(management|data|history) connection <token>".

For `aiormq<5.1.1` client_properties require an outer `{"client_properties": ...}`. and `aio-pika` depends on `aiormq<4` 😞 