### PR TITLE
feat: add `dict()` to value and aggrate types

### DIFF
--- a/metricq/types.py
+++ b/metricq/types.py
@@ -599,6 +599,16 @@ class TimeValue:
     def __iter__(self) -> Iterator[Union["Timestamp", float]]:
         return iter([self.timestamp, self.value])
 
+    def dict(self) -> dict[str, Any]:
+        """
+        returns a dict representing the TimeValue instance.
+        Keys are `timestamp` and `value`
+        """
+        return {
+            "timestamp": self.timestamp.posix_ns,
+            "value": self.value,
+        }
+
 
 @dataclass(frozen=True)
 class TimeAggregate:
@@ -702,6 +712,19 @@ class TimeAggregate:
     @property
     def mean_sum(self) -> float:
         return self.sum / self.count
+
+    def dict(self) -> dict[str, Any]:
+        """
+        returns a dict representing the TimeAggregate instance.
+        Keys are `timestamp`, `minimum`, `mean`, `maximum`, and `count`.
+        """
+        return {
+            "minimum": self.minimum,
+            "mean": self.mean,
+            "maximum": self.maximum,
+            "count": self.count,
+            "timestamp": self.timestamp.posix_ns,
+        }
 
 
 Metric = str

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,7 +6,7 @@ from typing import Generator, List, Union
 import pytest
 
 from metricq.exceptions import NonMonotonicTimestamps
-from metricq.types import TimeAggregate, Timedelta, Timestamp
+from metricq.types import TimeAggregate, Timedelta, Timestamp, TimeValue
 
 logger = getLogger(__name__)
 
@@ -240,6 +240,31 @@ def test_timeaggregate_from_value_pair(
     assert isclose(agg.mean, VALUE)
     assert isclose(agg.mean_integral, VALUE)
     assert isclose(agg.mean_sum, VALUE)
+
+
+def test_dict_from_aggregate(timestamp: Timestamp, time_delta_10s: Timedelta) -> None:
+    VALUE = 42.0
+    later = timestamp + time_delta_10s
+    agg = TimeAggregate.from_value_pair(
+        timestamp_before=timestamp, timestamp=later, value=VALUE
+    ).dict()
+
+    assert agg["timestamp"] == timestamp.posix_ns
+    assert agg["count"] == 1
+
+    assert agg["minimum"] == VALUE
+    assert agg["maximum"] == VALUE
+
+    assert isclose(agg["mean"], VALUE)
+
+
+def test_dict_from_value(timestamp: Timestamp) -> None:
+    VALUE = 42.0
+
+    val = TimeValue(timestamp, VALUE).dict()
+
+    assert val["timestamp"] == timestamp.posix_ns
+    assert val["value"] == VALUE
 
 
 def test_timeaggregate_from_value_pair_non_monotonic(


### PR DESCRIPTION
Adding a similiar method `dict()` to `TimeValue` and `TimeAggregate` classes that allow to convert the types easily into a dict, which can be directly represented as JSON. Trying to stay as closely as possible to the python interface with key-values of the dict.

Fixes #121 