### PR TITLE
fix: exception in update zombifies IntervalSource

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ recursive-include tools *.py
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.json
+include docs/_static/custom.css
 include docs/.nojekyll
 include docs/Makefile
 include docs/make.bat
@@ -26,3 +27,4 @@ exclude .git-blame-ignore-revs
 exclude .gitmodules
 exclude .pre-commit-config.yaml
 exclude .github_changelog_generator
+exclude .dockerignore

--- a/metricq/interval_source.py
+++ b/metricq/interval_source.py
@@ -136,6 +136,12 @@ class IntervalSource(Source):
                 # During the reconnection phase, we need to save the task from
                 # being cancelled.
                 logger.debug("Failed to send metric value: {}", e)
+            except Exception as e:
+                # Some exception escaped from the client, we want to stop the
+                # zombie apocalypse, so we request a stop here. If agents don't
+                # handle their exceptions, we will. Again, we need to save the
+                # task from being cancelled.
+                await self.stop(e)
 
             try:
                 if self._period is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ ignore = [
 
 [tool.mypy]
 exclude = 'setup.py|\.?.*env|conf.py|build'
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
If during the processing of the `update` coroutine, an exception gets raised, the periodic `task` gets cancelled. This patch catches any exception and stops the client with the exception as reason.

Fixes #134