### PR TITLE
Fix version guessing for protoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,9 +87,9 @@ def make_protobuf_requirement(major: int, minor: int, patch: int) -> str:
     protobuf_python_version = metadata.version("protobuf")
     # minor and patch versions match
     assert [str(minor), str(patch)] == protobuf_python_version.split(".")[1:3], \
-        f"protobuf and protoc must have compatible versions " \
-        "(minor and patch match; protobuf: {protobuf_python_version}, " \
-        "protoc: {major}.{minor}.{patch})"
+        "protobuf and protoc must have compatible versions " \
+        f"(minor and patch match; protobuf: {protobuf_python_version}, " \
+        f"protoc: {major}.{minor}.{patch})"
 
     # pin required protobuf-python version
     return f"protobuf=={protobuf_python_version}"


### PR DESCRIPTION
Dear maintainers,

this PR fixes a problem which I encountered when using metricq-python not via pip.

Note that as this tests the installation process, for which unit testing is not implemented in metricq-python:
There are no tests included in this PR. I am confident that manual review will be sufficient for this small change.

How well this approach will work in practice is not clear to me, as it requires an exact match of the protobuf version during runtime.
However, it is the best solution I came up with given the circumstances.

Description:

During the build process, protoc is invoked to build protobuf files. These built files are deployed to users, and thus the users require a compatible python-protobuf version at runtime.

For that, the required protobuf version is set during the build process in setup.py. However, this version selection is not up to date with the versioning scheme used by protobuf. protobuf keeps the major version independent between languages, and minor/patch versions in sync. E.g., as of the time of writing, python-protobuf 4.21.12 is compatible with libprotoc 3.21.12.
see: https://protobuf.dev/news/2022-05-06/

However, it is not clear under which circumstances these versions are compatible to each other. (I.e., even if minor/patch version are different, the binary format may still be compatible.) This makes correctly predicting the required (potentially unrealeased) python-protobuf version impossible.

This patch takes a conservative approach: It manually ensures that minor/patch versions align *during build*, and then requires the *exact* python-protobuf used during building also during runtime. As a consequence, only readily available python-protobuf versions should be used during building, in order to prevent complications for users.