### PR TITLE
ci: replace protoc action with plain old apt-get

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/386
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Protoc
-        uses: arduino/setup-protoc@master
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -53,7 +55,9 @@ jobs:
         with:
           python-version: ${{ env.release-python-version }}
       - name: Install Protoc
-        uses: arduino/setup-protoc@master
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -131,7 +135,9 @@ jobs:
         with:
           python-version: ${{ env.release-python-version }}
       - name: Install Protoc
-        uses: arduino/setup-protoc@master
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Install pip
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The arduino/protoc action gave a rate-limit error and failed the whole
pipeline.