### PR TITLE
Read protobuf version directly in setup.py

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -141,21 +141,9 @@ jobs:
       - name: Install pip
         run: |
           python -m pip install --upgrade pip
-      - name: Install build dependencies
-        # To build the protobuf files (see below why they are necessary), install
-        # all necessary build dependencies.  This is currently the least painful
-        # solution. See https://github.com/pypa/pip/issues/8049#issuecomment-633845028
-        run: |
-          pip install toml
-          python -c 'import toml; print("\n".join(toml.load("pyproject.toml")["build-system"]["requires"]))' \
-            | pip install -r /dev/stdin
       - name: Install dependencies
         run: |
           pip install '.[docs]'
-      - name: Build protobuf files
-        # Sphinx autodoc needs to import from generated *_pb2.py files
-        run: |
-          python setup.py build_protobuf
       - name: Build documentation
         run: |
           # run HTML builder (-b) in nitpicky mode (-n) in a fresh environment (-E)

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -149,7 +149,6 @@ If you have imported types from it directly you should change to import directly
 * :class:`Metric` (available in `metricq` since `5.0`)
 * :class:`JsonDict` (available in `metricq` since `5.0`)
 
-
 Deprecation of `dict` methods
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -157,3 +156,8 @@ The methods :meth:`TimeAggregate.dict` and :meth:`TimeValue.dict` have been depr
 Use the individual fields instead.
 The using code has more context and should know better which fields to include.
 In particular, whether to use :attr:`TimeAggregate.mean_sum` or :meth:`TimeAggregate.mean_integral` and which :attr:`TimeValue.timestamp` type to use.
+
+Renaming of setup.py options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The user option ``out-dir`` has been renamed to ``package-dir``.


### PR DESCRIPTION
fixes #162

This will need more testing. Maybe we need to use `out_dir` instead of the current working dir to find the module file. Nothing is documented, it all depends on the installation in which setup.py is invoked, local install, packaging, pip, or whatever...