### PR TITLE
Fix interval source

### DIFF
--- a/docs/api/source.rst
+++ b/docs/api/source.rst
@@ -10,6 +10,7 @@ Source
         chunk_size,
         flush,
         teardown,
+        task_stop_future,
     :member-order: groupwise
 
 ----

--- a/metricq/agent.py
+++ b/metricq/agent.py
@@ -97,10 +97,10 @@ class Agent(RPCDispatcher):
       * calls :meth:`connect` and :meth:`stopped` to run indefinitely until
         :meth:`stop` is called.
 
-    Within :meth:`stop`, the Agent will invoke :meth:`close` to allow the all child
+    Within :meth:`stop`, the Agent will invoke :meth:`teardown` to allow the all child
     classes to perform any necessary cleanup. Implementations of :meth:`teardown` should
     call ``super().teardown()``, possibly in an ``asyncio.gather``. :meth:`stop`
-    wraps the invocation of :meth:`close` in a timeout (``_close_timeout``) and logs any
+    wraps the invocation of :meth:`teardown` in a timeout (``_close_timeout``) and logs any
     errors during cleanup, possibly passing it to anyone waiting for :meth:`stopped`.
     """
 


### PR DESCRIPTION
Turns out the stop procedure of the `IntervalSource` was completely broken in the 5.0 refactoring :panda_face: .

So here's a fix, and some documentation fixes I stumbled upon.