### PR TITLE
feat(agent): redacted url

### DIFF
--- a/metricq/agent.py
+++ b/metricq/agent.py
@@ -184,6 +184,16 @@ class Agent(RPCDispatcher):
             __version__,
         )
 
+    @property
+    def url(self) -> str:
+        """
+        The management URL with the password replaced by '******', if user present.
+        """
+        url = URL(self._management_url)
+        if url.user:
+            return str(url.with_password("******"))
+        return self._management_url
+
     def derive_address(self, address: str) -> str:
         """Add the credentials from the management connection to the provided address
 
@@ -244,7 +254,7 @@ class Agent(RPCDispatcher):
         """Connect to the MetricQ network"""
         logger.info(
             "establishing management connection to {}",
-            URL(self._management_url).with_password("******"),
+            self.url,
         )
 
         try:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -25,3 +25,13 @@ def test_agent_url_and_management_url() -> None:
                 url="amqps://test.invalid",
                 management_url="amqps://test.invalid",
             )
+
+
+def test_agent_redacted_url() -> None:
+    agent = Agent(token="test", url="amqps://user:password@test.invalid")
+    assert agent.url == "amqps://user:******@test.invalid"
+
+
+def test_agent_redacted_url_no_login_info() -> None:
+    agent = Agent(token="test", url="amqps://test.invalid")
+    assert agent.url == "amqps://test.invalid"


### PR DESCRIPTION
This PR adds the `Agent.url` property, which is a redacted _management_url. See #169 