### PR TITLE
feat(time_aggregate): mean_sum return NaN

### DIFF
--- a/metricq/timeseries/time_aggregate.py
+++ b/metricq/timeseries/time_aggregate.py
@@ -135,7 +135,7 @@ class TimeAggregate:
         This value will be `NaN` if there are no raw data points in the
         aggregate interval.
         """
-        return self.sum / self.count
+        return self.sum / self.count if self.count != 0 else float("NaN")
 
     @deprecated(
         version="5.0.0",

--- a/tests/test_history_client.py
+++ b/tests/test_history_client.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any
 
 import pytest
@@ -66,6 +67,24 @@ async def test_history_aggregate(
     assert await history_client.history_aggregate(
         DEFAULT_METRIC
     ) == TimeAggregate.from_proto(timestamp=time, proto=aggregate)
+
+
+def test_history_aggregate_with_zero_count(
+    history_client: HistoryClient, mocker: MockerFixture
+) -> None:
+    time = Timestamp(0)
+    aggregate = history_pb2.HistoryResponse.Aggregate(count=0)
+
+    response = mock_history_response(
+        time_delta=[time.posix_ns],
+        aggregate=[aggregate],
+    )
+
+    patch_history_data_request(mocker, response)
+
+    agg = TimeAggregate.from_proto(timestamp=time, proto=aggregate)
+
+    assert math.isnan(agg.mean_sum)
 
 
 async def test_history_no_aggregate(


### PR DESCRIPTION
Adds the behavior from #186, so it returns `NaN` from the `means_sum` if the `count` is 0.

