### PR TITLE
feat: metricq_syslog_option

### DIFF
--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -17,7 +17,7 @@ Decorators
 ----------
 
 .. automodule:: metricq.cli.decorator
-    :members: metricq_command, metricq_metric_option, metricq_server_option, metricq_token_option,
+    :members: metricq_command, metricq_metric_option, metricq_server_option, metricq_syslog_option, metricq_token_option,
 
 
 Parameter

--- a/metricq/cli/__init__.py
+++ b/metricq/cli/__init__.py
@@ -2,6 +2,7 @@ from .decorator import (
     metricq_command,
     metricq_metric_option,
     metricq_server_option,
+    metricq_syslog_option,
     metricq_token_option,
 )
 from .params import (
@@ -23,5 +24,6 @@ __all__ = [
     "metricq_command",
     "metricq_metric_option",
     "metricq_server_option",
+    "metricq_syslog_option",
     "metricq_token_option",
 ]

--- a/metricq/cli/syslog.py
+++ b/metricq/cli/syslog.py
@@ -1,0 +1,32 @@
+import logging
+import socket
+import time
+from logging.handlers import SysLogHandler
+
+
+class SyslogFormatter(logging.Formatter):
+    def __init__(self, *args, name: str = "metricq", **kwargs):  # type: ignore
+        super().__init__(*args, **kwargs)
+        self.program = name
+
+    def format(self, record: logging.LogRecord) -> str:
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(record.created))
+        hostname = socket.gethostname()
+        pid = record.process
+        program = self.program
+        # Custom Formatter based on rfc3164
+        # Format the header as "<PRI> TIMESTAMP HOSTNAME PROGRAM[PID]: MESSAGE"
+        # <PRI> is already being set by the SysLogHandler, we only need to add the rest
+        syslog_header = f"{timestamp} {hostname} {program}[{pid}]: "
+        message = super().format(record)
+        return syslog_header + message
+
+
+def get_syslog_handler(address: str | None) -> SysLogHandler:
+    if address is None:
+        return SysLogHandler()
+    elif ":" in address:
+        ip, port = address.split(":")
+        return SysLogHandler(address=(ip, int(port)))
+    else:
+        return SysLogHandler(address=address)


### PR DESCRIPTION
Introducing the @metricq_syslog() wrapper for click commands, that configures the logger to sent to a Syslog Location (local or remote)